### PR TITLE
Revert "refactor: use tokio async pattern (#15)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,22 +4684,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ tiny-keccak = { version = "2.0.0", features = ["sha3", "keccak"] }
 rand = "0.8.5"
 eth-keystore = "0.5.0"
 rlp = "0.5.2"
-tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
+tokio = "1.37.0"
 sled = "0.34.7"
 http = "1.1.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::sync::Arc;
 
 use scroll_proving_sdk::{
     config::{CloudProverConfig, Config},
@@ -59,5 +60,7 @@ fn main() -> anyhow::Result<()> {
         .with_proving_service(Box::new(cloud_prover))
         .build()?;
 
-    Arc::new(prover).run()
+    Arc::new(prover).run()?;
+
+    loop {}
 }

--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -49,8 +49,7 @@ impl CloudProver {
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     init_tracing();
 
     let args = Args::parse();
@@ -60,7 +59,5 @@ async fn main() -> anyhow::Result<()> {
         .with_proving_service(Box::new(cloud_prover))
         .build()?;
 
-    prover.run().await;
-
-    Ok(())
+    Arc::new(prover).run()
 }

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -43,8 +43,7 @@ impl LocalProver {
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<()> {
     init_tracing();
 
     let args = Args::parse();
@@ -54,7 +53,5 @@ async fn main() -> anyhow::Result<()> {
         .with_proving_service(Box::new(local_prover))
         .build()?;
 
-    prover.run().await;
-
-    Ok(())
+    Arc::new(prover).run()
 }

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::sync::Arc;
 
 use scroll_proving_sdk::{
     config::{Config, LocalProverConfig},
@@ -53,5 +54,7 @@ fn main() -> anyhow::Result<()> {
         .with_proving_service(Box::new(local_prover))
         .build()?;
 
-    Arc::new(prover).run()
+    Arc::new(prover).run()?;
+
+    loop {}
 }

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -3,7 +3,8 @@ use super::{
     LoginRequest, Response, SubmitProofRequest, SubmitProofResponseData,
 };
 use crate::{config::CoordinatorConfig, prover::CircuitType, utils::get_version};
-use tokio::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard};
+use tokio::runtime::Runtime;
 
 pub struct CoordinatorClient {
     circuit_type: CircuitType,
@@ -13,6 +14,7 @@ pub struct CoordinatorClient {
     key_signer: KeySigner,
     api: Api,
     token: Mutex<Option<String>>,
+    rt: Runtime,
 }
 
 impl CoordinatorClient {
@@ -24,6 +26,9 @@ impl CoordinatorClient {
         prover_name: String,
         key_signer: KeySigner,
     ) -> anyhow::Result<Self> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
         let api = Api::new(cfg)?;
         let client = Self {
             circuit_type,
@@ -33,38 +38,56 @@ impl CoordinatorClient {
             key_signer,
             api,
             token: Mutex::new(None),
+            rt,
         };
         Ok(client)
     }
 
-    pub async fn get_task(
-        &self,
-        req: &GetTaskRequest,
-    ) -> anyhow::Result<Response<GetTaskResponseData>> {
-        let token = self.get_token(false).await?;
-        let response = self.api.get_task(req, &token).await?;
+    pub fn get_task(&self, req: &GetTaskRequest) -> anyhow::Result<Response<GetTaskResponseData>> {
+        let token = self.get_token_sync(false)?;
+        let response = self.get_task_sync(req, &token)?;
 
         if response.errcode == ErrorCode::ErrJWTTokenExpired {
-            let token = self.get_token(true).await?;
-            self.api.get_task(req, &token).await
+            let token = self.get_token_sync(true)?;
+            self.get_task_sync(req, &token)
         } else {
             Ok(response)
         }
     }
 
-    pub async fn submit_proof(
+    pub fn submit_proof(
         &self,
         req: &SubmitProofRequest,
     ) -> anyhow::Result<Response<SubmitProofResponseData>> {
-        let token = self.get_token(false).await?;
-        let response = self.api.submit_proof(req, &token).await?;
+        let token = self.get_token_sync(false)?;
+        let response = self.submit_proof_sync(req, &token)?;
 
         if response.errcode == ErrorCode::ErrJWTTokenExpired {
-            let token = self.get_token(true).await?;
-            self.api.submit_proof(req, &token).await
+            let token = self.get_token_sync(true)?;
+            self.submit_proof_sync(req, &token)
         } else {
             Ok(response)
         }
+    }
+
+    fn get_task_sync(
+        &self,
+        req: &GetTaskRequest,
+        token: &String,
+    ) -> anyhow::Result<Response<GetTaskResponseData>> {
+        self.rt.block_on(self.api.get_task(req, token))
+    }
+
+    fn submit_proof_sync(
+        &self,
+        req: &SubmitProofRequest,
+        token: &String,
+    ) -> anyhow::Result<Response<SubmitProofResponseData>> {
+        self.rt.block_on(self.api.submit_proof(req, token))
+    }
+
+    fn get_token_sync(&self, force_relogin: bool) -> anyhow::Result<String> {
+        self.rt.block_on(self.get_token_async(force_relogin))
     }
 
     /// Retrieves a token for authentication, optionally forcing a re-login.
@@ -73,18 +96,21 @@ impl CoordinatorClient {
     ///
     /// If the token is expired, `force_relogin` is set to `true`, or a login was never performed
     /// before, it will authenticate and fetch a new token.
-    async fn get_token(&self, force_relogin: bool) -> anyhow::Result<String> {
-        let token_guard = self.token.lock().await;
+    async fn get_token_async(&self, force_relogin: bool) -> anyhow::Result<String> {
+        let token_guard = self
+            .token
+            .lock()
+            .expect("Mutex locking only occurs within `get_token` fn, so there can be no double `lock` for one thread");
 
-        match *token_guard {
-            Some(ref token) if !force_relogin => return Ok(token.to_string()),
+        match token_guard.as_deref() {
+            Some(token) if !force_relogin => return Ok(token.to_string()),
             _ => (),
         }
 
-        self.login(token_guard).await
+        self.login_async(token_guard).await
     }
 
-    async fn login<'t>(
+    async fn login_async<'t>(
         &self,
         mut token_guard: MutexGuard<'t, Option<String>>,
     ) -> anyhow::Result<String> {

--- a/src/tracing_handler.rs
+++ b/src/tracing_handler.rs
@@ -6,20 +6,25 @@ use prover_darwin_v2::BlockTrace;
 use serde::{de::DeserializeOwned, Serialize};
 use std::cmp::Ordering;
 use std::fmt::Debug;
+use tokio::runtime::Runtime;
 
 pub type CommonHash = H256;
 
 pub struct L2gethClient {
     provider: Provider<Http>,
+    rt: Runtime,
 }
 
 impl L2gethClient {
     pub fn new(cfg: L2GethConfig) -> anyhow::Result<Self> {
         let provider = Provider::<Http>::try_from(cfg.endpoint)?;
-        Ok(Self { provider })
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        Ok(Self { provider, rt })
     }
 
-    pub async fn get_block_trace_by_hash<T>(&self, hash: &CommonHash) -> anyhow::Result<T>
+    async fn get_block_trace_by_hash_async<T>(&self, hash: &CommonHash) -> anyhow::Result<T>
     where
         T: Serialize + DeserializeOwned + Debug + Send,
     {
@@ -35,14 +40,25 @@ impl L2gethClient {
         Ok(trace)
     }
 
-    pub async fn block_number(&self) -> anyhow::Result<BlockNumber> {
+    pub fn get_block_trace_by_hash_sync<T>(&self, hash: &CommonHash) -> anyhow::Result<T>
+    where
+        T: Serialize + DeserializeOwned + Debug + Send,
+    {
+        self.rt.block_on(self.get_block_trace_by_hash_async(hash))
+    }
+
+    async fn block_number_async(&self) -> anyhow::Result<BlockNumber> {
         log::info!("l2geth_client calling block_number");
 
         let trace = self.provider.request("eth_blockNumber", ()).await?;
         Ok(trace)
     }
 
-    pub async fn get_sorted_traces_by_hashes(
+    pub fn block_number_sync(&self) -> anyhow::Result<BlockNumber> {
+        self.rt.block_on(self.block_number_async())
+    }
+
+    pub fn get_sorted_traces_by_hashes(
         &self,
         block_hashes: &[CommonHash],
     ) -> anyhow::Result<Vec<BlockTrace>> {
@@ -53,7 +69,7 @@ impl L2gethClient {
 
         let mut block_traces = Vec::new();
         for hash in block_hashes.iter() {
-            let trace = self.get_block_trace_by_hash(hash).await?;
+            let trace = self.get_block_trace_by_hash_sync(hash)?;
             block_traces.push(trace);
         }
 


### PR DESCRIPTION
revert because 
```
Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
```