### PR TITLE
add LICENSE & README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2024 Scroll
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -4,19 +4,19 @@
 
 ## Introduction
 
-Scroll Proving SDK is a Rust library for building services that interfaces with [Scroll SDK](https://github.com/scroll-tech/scroll-sdk)'s Coordinator.
+Scroll Proving SDK is a Rust library for building services that interface with the [Scroll SDK](https://github.com/scroll-tech/scroll-sdk) Coordinator service.
 
-It is designed to be used in conjunction with the Scroll SDK, allowing proof generation to be outsourced easily to third parties for chain operators, without them needing to run their own full node or know how to register for tasks on your network. 
+It is designed to be used in conjunction with the Scroll SDK, allowing proof generation to be outsourced easily to third parties, without proof generators needing to run their own full node or know about your network. 
 
 ## Repo Structure
 This repo contains:
 - `src/`: Core Rust library implementing the proving service interface
-- `examples/`: Example implementations of proving services using this SDK
+- `examples/`: Example implementations of external proving services using this SDK
 - `docker`: Dockerfile for creating containerized versions of the examples
 - `charts/scroll-proving-sdk`: Helm chart for deploying the examples on Kubernetes
 - `docs/`: Documentation and implementation information
 
-## Services Build with Scroll Proving SDK
+## Services Built with the Scroll Proving SDK
 
 > [!NOTE]
 > The following charts are developed and maintained by third parties. Please use with caution.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,38 @@
+# Scroll Proving SDK
+[![Twitter Follow](https://img.shields.io/twitter/follow/Scroll_ZKP?style=social)](https://twitter.com/Scroll_ZKP)
+[![Discord](https://img.shields.io/discord/984015101017346058?color=%235865F2&label=Discord&logo=discord&logoColor=%23fff)](https://discord.gg/scroll)
+
+## Introduction
+
+Scroll Proving SDK is a Rust library for building services that interfaces with [Scroll SDK](https://github.com/scroll-tech/scroll-sdk)'s Coordinator.
+
+It is designed to be used in conjunction with the Scroll SDK, allowing proof generation to be outsourced easily to third parties for chain operators, without them needing to run their own full node or know how to register for tasks on your network. 
+
+## Repo Structure
+This repo contains:
+- `src/`: Core Rust library implementing the proving service interface
+- `examples/`: Example implementations of proving services using this SDK
+- `docker`: Dockerfile for creating containerized versions of the examples
+- `charts/scroll-proving-sdk`: Helm chart for deploying the examples on Kubernetes
+- `docs/`: Documentation and implementation information
+
+## Services Build with Scroll Proving SDK
+
+> [!NOTE]
+> The following charts are developed and maintained by third parties. Please use with caution.
+
+Proving Services:
+- [Sindri](https://github.com/Sindri-Labs/sindri-scroll-sdk/)
+
+## Other Scroll SDK Repos
+
+- [Scroll SDK](https://www.github.com/scroll-tech/scroll-sdk)
+- [Scroll SDK CLI](https://www.github.com/scroll-tech/scroll-sdk-cli)
+
+## Contributing
+
+The SDK is currently under heavy development, so if you wish to contribute, we recommend reaching out and coordinating closely with the Scroll team or raising an issue on the repo.
+
+## License
+
+This project is licensed under the MIT License. See the [LICENSE](./LICENSE) file for more details.


### PR DESCRIPTION
Adds a readme and license file.

Todo:
- migrate chart files from `haoyu/sindri_tokio`

Follow-up:
- setup auto-gen docs