### PR TITLE
Allow SDK consumers construct their own Configs

### DIFF
--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -1,9 +1,11 @@
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::Url;
+use std::fs::File;
 
 use scroll_proving_sdk::{
-    config::{CloudProverConfig, Config},
+    config::Config as SdkConfig,
     prover::{
         proving_service::{
             GetVkRequest, GetVkResponse, ProveRequest, ProveResponse, QueryTaskRequest,
@@ -13,6 +15,7 @@ use scroll_proving_sdk::{
     },
     utils::init_tracing,
 };
+use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Debug)]
 #[clap(disable_version_flag = true)]
@@ -20,6 +23,51 @@ struct Args {
     /// Path of config file
     #[arg(long = "config", default_value = "config.json")]
     config_file: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CloudProverConfig {
+    pub sdk_config: SdkConfig,
+    pub base_url: String,
+    pub api_key: String,
+}
+
+impl CloudProverConfig {
+    pub fn from_reader<R>(reader: R) -> Result<Self>
+    where
+        R: std::io::Read,
+    {
+        serde_json::from_reader(reader).map_err(|e| anyhow!(e))
+    }
+
+    pub fn from_file(file_name: String) -> Result<Self> {
+        let file = File::open(file_name)?;
+        Self::from_reader(&file)
+    }
+
+    fn get_env_var(key: &str) -> Result<Option<String>> {
+        std::env::var_os(key)
+            .map(|val| {
+                val.to_str()
+                    .ok_or_else(|| anyhow!("{key} env var is not valid UTF-8"))
+                    .map(String::from)
+            })
+            .transpose()
+    }
+
+    pub fn from_file_and_env(file_name: String) -> Result<Self> {
+        let mut cfg = Self::from_file(file_name)?;
+
+        if let Some(val) = Self::get_env_var("PROVING_SERVICE_BASE_URL")? {
+            cfg.base_url = val;
+        }
+
+        if let Some(val) = Self::get_env_var("PROVING_SERVICE_API_KEY")? {
+            cfg.api_key = val;
+        }
+
+        Ok(cfg)
+    }
 }
 
 struct CloudProver {
@@ -58,14 +106,10 @@ async fn main() -> anyhow::Result<()> {
     init_tracing();
 
     let args = Args::parse();
-    let cfg: Config = Config::from_file_and_env(args.config_file)?;
-    let cloud_prover = CloudProver::new(
-        cfg.prover
-            .cloud
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("Missing cloud prover configuration"))?,
-    );
-    let prover = ProverBuilder::new(cfg)
+    let cfg = CloudProverConfig::from_file_and_env(args.config_file)?;
+    let sdk_config = cfg.sdk_config.clone();
+    let cloud_prover = CloudProver::new(cfg);
+    let prover = ProverBuilder::new(sdk_config)
         .with_proving_service(Box::new(cloud_prover))
         .build()
         .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,32 +36,7 @@ pub struct ProverConfig {
     pub circuit_version: String,
     #[serde(default = "default_n_workers")]
     pub n_workers: usize,
-    pub cloud: Option<CloudProverConfig>,
-    pub local: Option<LocalProverConfig>,
 }
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CloudProverConfig {
-    pub base_url: String,
-    pub api_key: String,
-    pub retry_count: u32,
-    pub retry_wait_time_sec: u64,
-    pub connection_timeout_sec: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct LocalProverConfig {
-    pub low_version_circuit: CircuitConfig,
-    pub high_version_circuit: CircuitConfig,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct CircuitConfig {
-    pub hard_fork_name: String,
-    pub params_path: String,
-    pub assets_path: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbConfig {}
 
@@ -136,37 +111,15 @@ impl Config {
                 })
                 .collect::<Vec<CircuitType>>();
         }
-        if let Some(val) = Self::get_env_var("PROVING_SERVICE_BASE_URL")? {
-            if let Some(cloud) = &mut self.prover.cloud {
-                cloud.base_url = val;
-            }
-        }
+
         if let Some(val) = Self::get_env_var("N_WORKERS")? {
             self.prover.n_workers = val.parse()?;
         }
-        if let Some(val) = Self::get_env_var("PROVING_SERVICE_API_KEY")? {
-            if let Some(cloud) = &mut self.prover.cloud {
-                cloud.api_key = val;
-            }
-        }
+
         if let Some(val) = Self::get_env_var("DB_PATH")? {
             self.db_path = Option::from(val);
         }
 
         Ok(())
-    }
-}
-
-impl LocalProverConfig {
-    pub fn from_reader<R>(reader: R) -> Result<Self>
-    where
-        R: std::io::Read,
-    {
-        serde_json::from_reader(reader).map_err(|e| anyhow!(e))
-    }
-
-    pub fn from_file(file_name: String) -> Result<Self> {
-        let file = File::open(file_name)?;
-        LocalProverConfig::from_reader(&file)
     }
 }


### PR DESCRIPTION
Proving services are constructed outside of the SDK and provided to ProverBuilder dynamically anyways. There is no reason for SDK to define the configurations for proving services.