### PR TITLE
feat: cloud prover many fixs and feats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rlp"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,10 +685,10 @@ dependencies = [
  "num_enum",
  "open-fastrlp",
  "rand 0.8.5",
- "rlp 0.5.2",
+ "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.24.1",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -1200,7 +1222,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.5.2",
+ "rlp",
 ]
 
 [[package]]
@@ -2006,16 +2028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
 name = "rlp-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,24 +2159,27 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll-proving-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "alloy-rlp",
  "async-trait",
  "axum",
  "clap",
  "dotenvy",
  "ethers-core",
  "eyre",
+ "futures",
  "hex",
  "http",
  "rand 0.9.2",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "rlp 0.6.1",
  "rocksdb",
  "serde",
  "serde_json",
+ "serde_repr",
+ "strum 0.27.2",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -2249,6 +2264,17 @@ dependencies = [
  "ryu",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2371,7 +2397,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
 ]
 
 [[package]]
@@ -2385,6 +2420,18 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +201,21 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -386,6 +410,33 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -909,6 +960,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1558,6 +1615,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1703,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parity-scale-codec"
@@ -2049,6 +2121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2243,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap",
+ "color-eyre",
  "dotenvy",
  "ethers-core",
  "eyre",
@@ -2751,6 +2830,16 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,49 +3,25 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -58,44 +34,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -105,37 +81,26 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "0e86f6d3dc9dc4352edeea6b8e499e13e3f5dc3b964d7ca5fd411415a3498473"
 dependencies = [
- "flate2",
+ "compression-codecs",
+ "compression-core",
  "futures-core",
- "memchr",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "async_io_stream"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
-dependencies = [
- "futures",
- "pharos",
- "rustc_version",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -146,83 +111,65 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
- "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "serde_core",
+ "sync_wrapper",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
  "mime",
- "rustversion",
+ "pin-project-lite",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -233,46 +180,32 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -283,9 +216,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -310,15 +243,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -328,30 +261,30 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.14"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -368,20 +301,17 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
- "iana-time-zone",
  "num-traits",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -397,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -407,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -419,27 +349,44 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302266479cb963552d11bd042013a58ef1adc56768016c8b82b4199488f2d4ad"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const-oid"
@@ -449,9 +396,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -494,18 +441,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -514,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -530,16 +477,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -562,7 +503,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -585,14 +526,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "ecdsa"
@@ -610,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -627,7 +568,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -643,24 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enr"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "hex",
- "k256",
- "log",
- "rand",
- "rlp",
- "serde",
- "sha3",
- "zeroize",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,12 +591,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -739,8 +662,8 @@ dependencies = [
  "k256",
  "num_enum",
  "open-fastrlp",
- "rand",
- "rlp",
+ "rand 0.8.5",
+ "rlp 0.5.2",
  "serde",
  "serde_json",
  "strum",
@@ -751,39 +674,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers-providers"
-version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7#e32dfd62e7cdec31160b91c5a646883594a586ba"
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "enr",
- "ethers-core",
- "futures-channel",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "hex",
- "http 0.2.12",
- "instant",
+ "indenter",
  "once_cell",
- "pin-project",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -794,13 +691,19 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fixed-hash"
@@ -809,16 +712,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -847,9 +750,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -916,7 +819,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -930,16 +833,6 @@ name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -960,19 +853,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -981,52 +865,34 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasip2",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -1035,41 +901,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1079,18 +926,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
-]
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -1121,35 +959,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1159,27 +974,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
+ "futures-core",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1189,43 +1004,22 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-util",
- "h2 0.4.8",
- "http 1.2.0",
- "http-body 1.0.1",
- "httparse",
- "itoa",
- "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1233,32 +1027,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http 1.2.0",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.23",
+ "rustls",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1270,7 +1049,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1280,63 +1059,48 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
- "http 1.2.0",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
+ "windows-registry",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1346,103 +1110,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1451,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1474,7 +1200,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp",
+ "rlp 0.5.2",
 ]
 
 [[package]]
@@ -1494,14 +1220,20 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.7.1"
+name = "indenter"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1526,40 +1258,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
+name = "iri-string"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1576,7 +1319,6 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
- "signature",
 ]
 
 [[package]]
@@ -1595,32 +1337,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.17.1+9.9.3"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1633,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1644,31 +1380,30 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lz4-sys"
@@ -1682,24 +1417,24 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1715,22 +1450,23 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1762,12 +1498,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1797,23 +1532,20 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open-fastrlp"
@@ -1842,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1863,7 +1595,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1874,9 +1606,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1885,16 +1617,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parity-scale-codec"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1908,14 +1634,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.4"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1926,17 +1652,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1948,59 +1664,16 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.8",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pharos"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
-dependencies = [
- "futures",
- "rustc_version",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -2026,15 +1699,24 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -2065,30 +1747,36 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.22.24",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -2103,8 +1791,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2114,7 +1812,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2123,7 +1831,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2136,155 +1853,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
- "http 1.2.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.2.0",
- "reqwest 0.12.12",
+ "http",
+ "reqwest",
  "serde",
  "thiserror",
  "tower-service",
@@ -2292,21 +1941,21 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f342894422862af74c50e1e9601cf0931accc9c6981e5eb413c46603b616b5"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
  "futures",
- "getrandom 0.2.15",
- "http 1.2.0",
- "hyper 1.6.0",
- "parking_lot 0.11.2",
- "reqwest 0.12.12",
+ "getrandom 0.2.16",
+ "http",
+ "hyper",
+ "parking_lot",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
+ "thiserror",
  "tokio",
  "tracing",
  "wasm-timer",
@@ -2314,13 +1963,11 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493b4243e32d6eedd29f9a398896e35c6943a123b55eec97dcaee98310d25810"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "anyhow",
- "chrono",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2335,30 +1982,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -2370,6 +2002,16 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rlp-derive",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
+dependencies = [
+ "bytes",
  "rustc-hex",
 ]
 
@@ -2386,25 +2028,19 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -2413,118 +2049,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring 0.17.9",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
- "ring 0.17.9",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring 0.17.9",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scale-info"
@@ -2544,19 +2124,19 @@ version = "2.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2569,20 +2149,19 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 name = "scroll-proving-sdk"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "axum",
  "clap",
- "dotenv",
+ "dotenvy",
  "ethers-core",
- "ethers-providers",
+ "eyre",
  "hex",
- "http 1.2.0",
- "rand",
- "reqwest 0.12.12",
+ "http",
+ "rand 0.9.2",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "rlp",
+ "rlp 0.6.1",
  "rocksdb",
  "serde",
  "serde_json",
@@ -2590,17 +2169,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring 0.17.9",
- "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2623,7 +2191,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2632,72 +2200,55 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
-name = "send_wrapper"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
-
-[[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
-dependencies = [
- "itoa",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2713,21 +2264,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2760,54 +2300,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -2821,9 +2349,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2878,20 +2406,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2904,24 +2426,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2930,19 +2441,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -2963,16 +2464,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2992,17 +2492,16 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -3016,9 +2515,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3026,31 +2525,28 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3065,44 +2561,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.21.12",
+ "rustls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
-dependencies = [
- "rustls 0.23.23",
- "tokio",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite",
- "webpki-roots 0.23.1",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3113,9 +2584,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -3124,35 +2604,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow 0.7.3",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "winnow 0.7.13",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "toml_parser"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3164,8 +2638,26 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3188,7 +2680,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3196,33 +2687,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -3238,14 +2719,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3261,31 +2742,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15fba1a6d6bb030745759a9a2a588bfe8490fc8b4751a277db3a0be1c9ebbf67"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand",
- "rustls 0.21.12",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
- "webpki",
-]
-
-[[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uint"
@@ -3301,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -3313,38 +2773,21 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3387,50 +2830,37 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3441,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3451,22 +2881,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
- "wasm-bindgen-backend",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
@@ -3479,7 +2909,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3488,38 +2918,13 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring 0.17.9",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.3",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -3544,51 +2949,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -3602,26 +2994,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -3633,7 +3019,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -3641,10 +3027,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3653,10 +3050,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3665,10 +3062,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3677,16 +3074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3695,10 +3098,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3707,10 +3110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3719,16 +3122,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3741,62 +3150,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "ws_stream_wasm"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
-dependencies = [
- "async_io_stream",
- "futures",
- "js-sys",
- "log",
- "pharos",
- "rustc_version",
- "send_wrapper 0.6.0",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -3809,11 +3180,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -3821,69 +3191,79 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3892,20 +3272,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2578,7 +2578,6 @@ dependencies = [
  "ethers-providers",
  "hex",
  "http 1.2.0",
- "log",
  "rand",
  "reqwest 0.12.12",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,13 @@ name = "scroll-proving-sdk"
 version = "0.2.0"
 edition = "2024"
 
+[[bin]]
+name = "scroll-pover-db-tool"
+path = "src/bin/pover_db_tool.rs"
+
 [dependencies]
 eyre = "0.6"
+color-eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
@@ -27,3 +32,7 @@ dotenvy = "0.15"
 rocksdb = "0.24"
 strum = { version = "0.27", features = ["derive"] }
 serde_repr = "0.1"
+
+# ref: https://docs.rs/color-eyre/0.6.5/color_eyre/#improving-perf-on-debug-builds
+[profile.dev.package.backtrace]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,21 @@
 [package]
 name = "scroll-proving-sdk"
-version = "0.1.0"
-edition = "2021"
+version = "0.2.0"
+edition = "2024"
 
 [dependencies]
 eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-reqwest = { version = "0.12", features = ["gzip"] }
+futures = "0.3"
+reqwest = { version = "0.12", features = ["gzip", "json"] }
 reqwest-middleware = "0.4"
 reqwest-retry = "0.7"
 hex = "0.4"
 tiny-keccak = { version = "2.0", features = ["sha3", "keccak"] }
 rand = "0.9"
-rlp = "0.6"
+alloy-rlp = { version = "0.3", features = ["derive"] }
 tokio = { version = "1.48", features = ["net", "sync"] }
 async-trait = "0.1"
 http = "1.4"
@@ -24,4 +25,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1"] }
 dotenvy = "0.15"
 rocksdb = "0.24"
-
+strum = { version = "0.27", features = ["derive"] }
+serde_repr = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
@@ -21,8 +20,8 @@ tokio = { version = "1.37.0", features = ["full"] }
 async-trait = "0.1"
 http = "1.1.0"
 clap = { version = "4.5", features = ["derive"] }
-tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum = "0.6.0"
 dotenv = "0.15"
 rocksdb = "0.23.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,26 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0"
+eyre = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-reqwest = { version = "0.12.4", features = ["gzip"] }
-reqwest-middleware = "0.3"
-reqwest-retry = "0.5"
-hex = "0.4.3"
-tiny-keccak = { version = "2.0.0", features = ["sha3", "keccak"] }
-rand = "0.8.5"
-rlp = "0.5.2"
-tokio = { version = "1.37.0", features = ["full"] }
+reqwest = { version = "0.12", features = ["gzip"] }
+reqwest-middleware = "0.4"
+reqwest-retry = "0.7"
+hex = "0.4"
+tiny-keccak = { version = "2.0", features = ["sha3", "keccak"] }
+rand = "0.9"
+rlp = "0.6"
+tokio = { version = "1.48", features = ["net", "sync"] }
 async-trait = "0.1"
-http = "1.1.0"
+http = "1.4"
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-axum = "0.6.0"
-dotenv = "0.15"
-rocksdb = "0.23.0"
-url = "2.5.4"
+axum = { version = "0.8", default-features = false, features = ["tokio", "http1"] }
+dotenvy = "0.15"
+rocksdb = "0.24"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+use std::env;
+
+const DEFAULT_COMMIT: &str = "unknown";
+const DEFAULT_ZK_VERSION: &str = "000000-000000";
+const DEFAULT_TAG: &str = "v0.0.0";
+
+fn main() {
+    println!(
+        "cargo:rustc-env=GIT_REV={}",
+        env::var("GIT_REV").unwrap_or_else(|_| DEFAULT_COMMIT.to_string()),
+    );
+    println!(
+        "cargo:rustc-env=GO_TAG={}",
+        env::var("GO_TAG").unwrap_or_else(|_| DEFAULT_TAG.to_string()),
+    );
+    println!(
+        "cargo:rustc-env=ZK_VERSION={}",
+        env::var("ZK_VERSION").unwrap_or_else(|_| DEFAULT_ZK_VERSION.to_string()),
+    );
+}

--- a/conf/config.json
+++ b/conf/config.json
@@ -17,7 +17,8 @@
       2,
       3
     ],
-    "circuit_version": "v0.13.1"
+    "circuit_version": "v0.13.1",
+    "suppress_empty_task_error": true
   },
   "db_path": "db"
 }

--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -1,4 +1,5 @@
-use anyhow::{anyhow, Result};
+#![allow(dead_code)]
+use eyre::{eyre, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::Url;
@@ -37,7 +38,7 @@ impl CloudProverConfig {
     where
         R: std::io::Read,
     {
-        serde_json::from_reader(reader).map_err(|e| anyhow!(e))
+        serde_json::from_reader(reader).map_err(|e| eyre!(e))
     }
 
     pub fn from_file(file_name: String) -> Result<Self> {
@@ -49,7 +50,7 @@ impl CloudProverConfig {
         std::env::var_os(key)
             .map(|val| {
                 val.to_str()
-                    .ok_or_else(|| anyhow!("{key} env var is not valid UTF-8"))
+                    .ok_or_else(|| eyre!("{key} env var is not valid UTF-8"))
                     .map(String::from)
             })
             .transpose()
@@ -80,13 +81,13 @@ impl ProvingService for CloudProver {
     fn is_local(&self) -> bool {
         false
     }
-    async fn get_vks(&self, req: GetVkRequest) -> GetVkResponse {
+    async fn get_vks(&self, _req: GetVkRequest) -> GetVkResponse {
         todo!()
     }
-    async fn prove(&mut self, req: ProveRequest) -> ProveResponse {
+    async fn prove(&mut self, _req: ProveRequest) -> ProveResponse {
         todo!()
     }
-    async fn query_task(&mut self, req: QueryTaskRequest) -> QueryTaskResponse {
+    async fn query_task(&mut self, _req: QueryTaskRequest) -> QueryTaskResponse {
         todo!()
     }
 }
@@ -101,8 +102,8 @@ impl CloudProver {
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     init_tracing();
 
     let args = Args::parse();

--- a/examples/cloud.rs
+++ b/examples/cloud.rs
@@ -1,18 +1,18 @@
 #![allow(dead_code)]
-use eyre::{eyre, Result};
 use async_trait::async_trait;
 use clap::Parser;
+use eyre::{Result, eyre};
 use reqwest::Url;
 use std::fs::File;
 
 use scroll_proving_sdk::{
     config::Config as SdkConfig,
     prover::{
+        ProverBuilder, ProvingService,
         proving_service::{
             GetVkRequest, GetVkResponse, ProveRequest, ProveResponse, QueryTaskRequest,
             QueryTaskResponse,
         },
-        ProverBuilder, ProvingService,
     },
     utils::init_tracing,
 };

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -1,14 +1,14 @@
-use eyre::{eyre, Result};
 use async_trait::async_trait;
 use clap::Parser;
+use eyre::{Result, eyre};
 use scroll_proving_sdk::{
     config::Config as SdkConfig,
     prover::{
+        ProverBuilder, ProvingService,
         proving_service::{
             GetVkRequest, GetVkResponse, ProveRequest, ProveResponse, QueryTaskRequest,
             QueryTaskResponse,
         },
-        ProverBuilder, ProvingService,
     },
     utils::init_tracing,
 };

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use eyre::{eyre, Result};
 use async_trait::async_trait;
 use clap::Parser;
 use scroll_proving_sdk::{
@@ -35,7 +35,7 @@ impl LocalProverConfig {
     where
         R: std::io::Read,
     {
-        serde_json::from_reader(reader).map_err(|e| anyhow!(e))
+        serde_json::from_reader(reader).map_err(|e| eyre!(e))
     }
 
     pub fn from_file(file_name: String) -> Result<Self> {
@@ -56,25 +56,25 @@ impl ProvingService for LocalProver {
     fn is_local(&self) -> bool {
         true
     }
-    async fn get_vks(&self, req: GetVkRequest) -> GetVkResponse {
+    async fn get_vks(&self, _req: GetVkRequest) -> GetVkResponse {
         todo!()
     }
-    async fn prove(&mut self, req: ProveRequest) -> ProveResponse {
+    async fn prove(&mut self, _req: ProveRequest) -> ProveResponse {
         todo!()
     }
-    async fn query_task(&mut self, req: QueryTaskRequest) -> QueryTaskResponse {
+    async fn query_task(&mut self, _req: QueryTaskRequest) -> QueryTaskResponse {
         todo!()
     }
 }
 
 impl LocalProver {
-    pub fn new(cfg: LocalProverConfig) -> Self {
+    pub fn new(_cfg: LocalProverConfig) -> Self {
         Self {}
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     init_tracing();
 
     let args = Args::parse();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-02-14"
+channel = "nightly-2025-08-18"

--- a/src/bin/pover_db_tool.rs
+++ b/src/bin/pover_db_tool.rs
@@ -1,0 +1,81 @@
+use clap::{Parser, Subcommand};
+use eyre::WrapErr;
+use scroll_proving_sdk::db::{Db, PROVING_TASK_ID_KEY_PREFIX};
+use scroll_proving_sdk::utils::init_color_eyre_hook;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Tool to interact with the prover database.
+#[derive(Parser)]
+struct Cli {
+    /// Path to the database
+    #[clap(long, default_value = ".work/db")]
+    db: PathBuf,
+
+    #[command(subcommand)]
+    commands: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List all coordinator and prover task ID pairs
+    List,
+    /// Get the corresponding task ID
+    Get {
+        #[command(subcommand)]
+        commands: GetCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum GetCommands {
+    /// Get coordinator task ID by prover task ID
+    Coordinator { task_id: String },
+    /// Get prover task ID by coordinator task ID
+    Prover { task_id: String },
+}
+
+fn main() -> eyre::Result<()> {
+    init_color_eyre_hook();
+
+    let cli = Cli::parse();
+    let db = Db::new(&cli.db).context("open database")?;
+
+    let mut c2p = HashMap::new();
+    let mut p2c = HashMap::new();
+
+    for result in db.inner().prefix_iterator(PROVING_TASK_ID_KEY_PREFIX) {
+        let (proving_task_key_bytes, _) = result.context("iter entry")?;
+        let public_key =
+            std::str::from_utf8(&proving_task_key_bytes[PROVING_TASK_ID_KEY_PREFIX.len()..])?;
+
+        let Some((coordinator_task, prover_task_id)) = db.get_task(public_key) else {
+            continue;
+        };
+
+        c2p.insert(coordinator_task.task_id.clone(), prover_task_id.clone());
+        p2c.insert(prover_task_id, coordinator_task.task_id);
+    }
+
+    match cli.commands {
+        Commands::List => {
+            for (c_task_id, p_task_id) in c2p.iter() {
+                println!("{}\t{}", c_task_id, p_task_id);
+            }
+        }
+        Commands::Get { commands } => match commands {
+            GetCommands::Coordinator { task_id } => {
+                if let Some(coordinator_task_id) = p2c.get(&task_id) {
+                    println!("{coordinator_task_id}");
+                }
+            }
+            GetCommands::Prover { task_id } => {
+                if let Some(prover_task_id) = c2p.get(&task_id) {
+                    println!("{prover_task_id}");
+                }
+            }
+        },
+    }
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,8 +30,13 @@ pub struct ProverConfig {
     pub circuit_version: String,
     #[serde(default = "default_n_workers")]
     pub n_workers: usize,
+    /// Interval between polling the coordinator for new tasks.
     #[serde(default = "default_poll_interval_sec")]
     pub poll_interval_sec: u64,
+    /// Delay the timer by a randomly selected, evenly distributed amount of time between 0 and the
+    /// specified time value. Defaults to 0, indicating that no randomized delay shall be applied.
+    #[serde(default)]
+    pub randomized_delay_sec: u64,
     #[serde(default)]
     pub suppress_empty_task_error: bool,
 }
@@ -120,6 +125,9 @@ impl Config {
 
         if let Some(val) = Self::get_env_var("POLL_INTERVAL_SEC")? {
             self.prover.poll_interval_sec = val.parse()?;
+        }
+        if let Some(val) = Self::get_env_var("RANDOMIZED_DELAY_SEC")? {
+            self.prover.randomized_delay_sec = val.parse()?;
         }
 
         if Self::get_env_var("SUPPRESS_EMPTY_TASK_ERR")?.is_some() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,8 +39,6 @@ pub struct ProverConfig {
     /// specified time value. Defaults to 0, indicating that no randomized delay shall be applied.
     #[serde(default)]
     pub randomized_delay_sec: u64,
-    #[serde(default)]
-    pub suppress_empty_task_error: bool,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbConfig {}
@@ -142,10 +140,6 @@ impl Config {
         }
         if let Some(val) = Self::get_env_var("RANDOMIZED_DELAY_SEC")? {
             self.prover.randomized_delay_sec = val.parse()?;
-        }
-
-        if Self::get_env_var("SUPPRESS_EMPTY_TASK_ERR")?.is_some() {
-            self.prover.suppress_empty_task_error = true;
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{coordinator_handler::ProverType, prover::ProofType};
-use anyhow::{anyhow, Result};
-use dotenv::dotenv;
+use eyre::{eyre, Result};
+use dotenvy::dotenv;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fs::File;
@@ -47,7 +47,7 @@ impl Config {
     where
         R: std::io::Read,
     {
-        serde_json::from_reader(reader).map_err(|e| anyhow!(e))
+        serde_json::from_reader(reader).map_err(|e| eyre!(e))
     }
 
     pub fn from_file(file_name: String) -> Result<Self> {
@@ -65,7 +65,7 @@ impl Config {
         std::env::var_os(key)
             .map(|val| {
                 val.to_str()
-                    .ok_or_else(|| anyhow!("{key} env var is not valid UTF-8"))
+                    .ok_or_else(|| eyre!("{key} env var is not valid UTF-8"))
                     .map(String::from)
             })
             .transpose()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{coordinator_handler::ProverType, prover::ProofType};
-use eyre::{eyre, Result};
 use dotenvy::dotenv;
+use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fs::File;
@@ -22,6 +22,8 @@ pub struct CoordinatorConfig {
     pub retry_count: u32,
     pub retry_wait_time_sec: u64,
     pub connection_timeout_sec: u64,
+    #[serde(default)]
+    pub suppress_empty_task_error: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -37,8 +39,6 @@ pub struct ProverConfig {
     /// specified time value. Defaults to 0, indicating that no randomized delay shall be applied.
     #[serde(default)]
     pub randomized_delay_sec: u64,
-    #[serde(default)]
-    pub suppress_empty_task_error: bool,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbConfig {}
@@ -106,11 +106,12 @@ impl Config {
 
             self.prover.supported_proof_types = values_vec
                 .iter()
-                .map(|value| match value.parse::<u8>() {
-                    Ok(num) => ProofType::from_u8(num),
-                    Err(e) => {
-                        panic!("Failed to parse circuit type: {}", e);
-                    }
+                .map(|value| {
+                    value
+                        .parse::<u8>()
+                        .ok()
+                        .and_then(ProofType::from_repr)
+                        .expect("failed to parse circuit type")
                 })
                 .collect::<Vec<ProofType>>();
         }
@@ -120,7 +121,7 @@ impl Config {
         }
 
         if let Some(val) = Self::get_env_var("DB_PATH")? {
-            self.db_path = Option::from(val);
+            self.db_path = Some(val);
         }
 
         if let Some(val) = Self::get_env_var("POLL_INTERVAL_SEC")? {
@@ -131,7 +132,7 @@ impl Config {
         }
 
         if Self::get_env_var("SUPPRESS_EMPTY_TASK_ERR")?.is_some() {
-            self.prover.suppress_empty_task_error = true;
+            self.coordinator.suppress_empty_task_error = true;
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{coordinator_handler::ProverType, prover::ProofType};
-use eyre::{eyre, Result};
 use dotenvy::dotenv;
+use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use std::fs::File;
@@ -30,6 +30,10 @@ pub struct ProverConfig {
     pub circuit_version: String,
     #[serde(default = "default_n_workers")]
     pub n_workers: usize,
+    #[serde(default = "default_poll_interval_sec")]
+    pub poll_interval_sec: u64,
+    #[serde(default)]
+    pub suppress_empty_task_error: bool,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbConfig {}
@@ -38,8 +42,12 @@ fn default_health_listener_addr() -> String {
     "0.0.0.0:80".to_string()
 }
 
-fn default_n_workers() -> usize {
+const fn default_n_workers() -> usize {
     1
+}
+
+const fn default_poll_interval_sec() -> u64 {
+    20
 }
 
 impl Config {
@@ -108,6 +116,14 @@ impl Config {
 
         if let Some(val) = Self::get_env_var("DB_PATH")? {
             self.db_path = Option::from(val);
+        }
+
+        if let Some(val) = Self::get_env_var("POLL_INTERVAL_SEC")? {
+            self.prover.poll_interval_sec = val.parse()?;
+        }
+
+        if Self::get_env_var("SUPPRESS_EMPTY_TASK_ERR")?.is_some() {
+            self.prover.suppress_empty_task_error = true;
         }
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,15 @@ pub struct ProverConfig {
     pub circuit_version: String,
     #[serde(default = "default_n_workers")]
     pub n_workers: usize,
+    /// Interval between polling the coordinator for new tasks.
+    #[serde(default = "default_poll_interval_sec")]
+    pub poll_interval_sec: u64,
+    /// Delay the timer by a randomly selected, evenly distributed amount of time between 0 and the
+    /// specified time value. Defaults to 0, indicating that no randomized delay shall be applied.
+    #[serde(default)]
+    pub randomized_delay_sec: u64,
+    #[serde(default)]
+    pub suppress_empty_task_error: bool,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DbConfig {}
@@ -38,8 +47,12 @@ fn default_health_listener_addr() -> String {
     "0.0.0.0:80".to_string()
 }
 
-fn default_n_workers() -> usize {
+const fn default_n_workers() -> usize {
     1
+}
+
+const fn default_poll_interval_sec() -> u64 {
+    20
 }
 
 impl Config {
@@ -108,6 +121,17 @@ impl Config {
 
         if let Some(val) = Self::get_env_var("DB_PATH")? {
             self.db_path = Option::from(val);
+        }
+
+        if let Some(val) = Self::get_env_var("POLL_INTERVAL_SEC")? {
+            self.prover.poll_interval_sec = val.parse()?;
+        }
+        if let Some(val) = Self::get_env_var("RANDOMIZED_DELAY_SEC")? {
+            self.prover.randomized_delay_sec = val.parse()?;
+        }
+
+        if Self::get_env_var("SUPPRESS_EMPTY_TASK_ERR")?.is_some() {
+            self.prover.suppress_empty_task_error = true;
         }
 
         Ok(())

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -1,6 +1,6 @@
 use super::{
-    ChallengeResponseData, GetTaskRequest, GetTaskResponseData, LoginRequest, LoginResponseData,
-    Response, SubmitProofRequest, SubmitProofResponseData,
+    ChallengeResponse, GetTaskRequest, GetTaskResponse, LoginRequest, LoginResponse, Response,
+    SubmitProofRequest,
 };
 use crate::config::CoordinatorConfig;
 use core::time::Duration;
@@ -36,20 +36,16 @@ impl Api {
         })
     }
 
-    pub async fn challenge(&self) -> eyre::Result<ChallengeResponseData> {
+    pub async fn challenge(&self) -> eyre::Result<ChallengeResponse> {
         const PATH: &str = "/coordinator/v1/challenge";
-        let response: Response<ChallengeResponseData> =
+        let response: Response<ChallengeResponse> =
             self.request(Method::GET, PATH, None::<&()>, None).await?;
         response.into_result().context("challenge request failed")
     }
 
-    pub async fn login(
-        &self,
-        req: &LoginRequest<'_>,
-        token: &str,
-    ) -> eyre::Result<LoginResponseData> {
+    pub async fn login(&self, req: &LoginRequest<'_>, token: &str) -> eyre::Result<LoginResponse> {
         const PATH: &str = "/coordinator/v1/login";
-        let response: Response<LoginResponseData> = self
+        let response: Response<LoginResponse> = self
             .request(Method::POST, PATH, Some(req), Some(token))
             .await?;
         response.into_result().context("login failed")
@@ -59,7 +55,7 @@ impl Api {
         &self,
         req: &GetTaskRequest<'_>,
         token: &str,
-    ) -> eyre::Result<Response<GetTaskResponseData>> {
+    ) -> eyre::Result<Response<GetTaskResponse>> {
         const PATH: &str = "/coordinator/v1/get_task";
 
         if self.send_timeout < Duration::from_secs(600) {
@@ -77,7 +73,7 @@ impl Api {
         &self,
         req: &SubmitProofRequest<'_>,
         token: &str,
-    ) -> eyre::Result<Response<SubmitProofResponseData>> {
+    ) -> eyre::Result<Response<()>> {
         const PATH: &str = "/coordinator/v1/submit_proof";
         self.request(Method::POST, PATH, Some(req), Some(token))
             .await

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -4,10 +4,12 @@ use super::{
 };
 use crate::config::CoordinatorConfig;
 use core::time::Duration;
-use reqwest::{header::CONTENT_TYPE, Url};
+use eyre::Context;
+use http::{Method, StatusCode};
+use reqwest::{Url, header::CONTENT_TYPE};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
-use serde::Serialize;
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
+use serde::{Deserialize, Serialize};
 use tracing::Level;
 
 pub struct Api {
@@ -28,89 +30,38 @@ impl Api {
             .build();
 
         Ok(Self {
-            base_url: Url::parse(&cfg.base_url)?,
-            send_timeout: core::time::Duration::from_secs(cfg.connection_timeout_sec),
+            base_url: Url::parse(cfg.base_url.trim_end_matches('/'))?,
+            send_timeout: Duration::from_secs(cfg.connection_timeout_sec),
             client,
         })
     }
 
-    fn build_url(&self, method: &str) -> eyre::Result<Url> {
-        self.base_url.join(method).map_err(|e| eyre::eyre!(e))
-    }
-
-    #[instrument(skip(self, req, token), level = Level::DEBUG)]
-    async fn post_with_token<Req, Resp>(
-        &self,
-        method: &str,
-        req: &Req,
-        token: &String,
-    ) -> eyre::Result<Resp>
-    where
-        Req: ?Sized + Serialize,
-        Resp: serde::de::DeserializeOwned,
-    {
-        let url = self.build_url(method)?;
-        let request_body = serde_json::to_string(req)?;
-        let size = request_body.len();
-
-        debug!("sent request");
-        trace!(token = %token, request_body = %request_body, size = %size);
-        let response = self
-            .client
-            .post(url)
-            .header(CONTENT_TYPE, "application/json")
-            .bearer_auth(token)
-            .body(request_body)
-            .timeout(self.send_timeout)
-            .send()
-            .await?;
-
-        if response.status() != http::status::StatusCode::OK {
-            eyre::bail!(
-                "[coordinator client], {method}, status not ok: {}",
-                response.status()
-            )
-        }
-
-        let response_body = response.text().await?;
-
-        debug!("received response");
-        trace!(response_body = %response_body);
-        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
-    }
-
-    pub async fn challenge(&self) -> eyre::Result<Response<ChallengeResponseData>> {
-        let method = "/coordinator/v1/challenge";
-        let url = self.build_url(method)?;
-
-        let response = self
-            .client
-            .get(url)
-            .header(CONTENT_TYPE, "application/json")
-            .timeout(self.send_timeout)
-            .send()
-            .await?;
-
-        let response_body = response.text().await?;
-
-        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
+    pub async fn challenge(&self) -> eyre::Result<ChallengeResponseData> {
+        const PATH: &str = "/coordinator/v1/challenge";
+        let response: Response<ChallengeResponseData> =
+            self.request(Method::GET, PATH, None::<&()>, None).await?;
+        response.into_result().context("challenge request failed")
     }
 
     pub async fn login(
         &self,
-        req: &LoginRequest,
-        token: &String,
-    ) -> eyre::Result<Response<LoginResponseData>> {
-        let method = "/coordinator/v1/login";
-        self.post_with_token(method, req, token).await
+        req: &LoginRequest<'_>,
+        token: &str,
+    ) -> eyre::Result<LoginResponseData> {
+        const PATH: &str = "/coordinator/v1/login";
+        let response: Response<LoginResponseData> = self
+            .request(Method::POST, PATH, Some(req), Some(token))
+            .await?;
+        response.into_result().context("login failed")
     }
 
     pub async fn get_task(
         &self,
-        req: &GetTaskRequest,
-        token: &String,
+        req: &GetTaskRequest<'_>,
+        token: &str,
     ) -> eyre::Result<Response<GetTaskResponseData>> {
-        let method = "/coordinator/v1/get_task";
+        const PATH: &str = "/coordinator/v1/get_task";
+
         if self.send_timeout < Duration::from_secs(600) {
             tracing::warn!(
                 "get_task API is time-consuming, timeout setting is too low ({}), set it to more than 600s",
@@ -118,15 +69,63 @@ impl Api {
             );
         }
 
-        self.post_with_token(method, req, token).await
+        self.request(Method::POST, PATH, Some(req), Some(token))
+            .await
     }
 
     pub async fn submit_proof(
         &self,
-        req: &SubmitProofRequest,
-        token: &String,
+        req: &SubmitProofRequest<'_>,
+        token: &str,
     ) -> eyre::Result<Response<SubmitProofResponseData>> {
-        let method = "/coordinator/v1/submit_proof";
-        self.post_with_token(method, req, token).await
+        const PATH: &str = "/coordinator/v1/submit_proof";
+        self.request(Method::POST, PATH, Some(req), Some(token))
+            .await
+    }
+
+    #[instrument(skip(self, body, token), level = Level::DEBUG)]
+    async fn request<Req, T>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Req>,
+        token: Option<&str>,
+    ) -> eyre::Result<Response<T>>
+    where
+        Req: ?Sized + Serialize,
+        T: for<'de> Deserialize<'de>,
+    {
+        let url = self.base_url.join(path)?;
+
+        let mut builder = self
+            .client
+            .request(method, url)
+            .header(CONTENT_TYPE, "application/json")
+            .timeout(self.send_timeout);
+
+        if let Some(token) = token {
+            trace!(token = %token);
+            builder = builder.bearer_auth(token);
+        }
+
+        if let Some(body) = body {
+            let request_body = serde_json::to_string(body)?;
+            let size = request_body.len();
+            trace!(request_body = %request_body, size = %size);
+            builder = builder.body(request_body);
+        }
+
+        debug!("sending request");
+        let response = builder.send().await?;
+
+        if response.status() != StatusCode::OK {
+            eyre::bail!("{path}, status not ok: {}", response.status())
+        }
+
+        let response = response.text().await?;
+        debug!("received response");
+        trace!(response_body = %response);
+        let response = serde_json::from_str(&response)?;
+        Ok(response)
     }
 }

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -17,7 +17,7 @@ pub struct Api {
 }
 
 impl Api {
-    pub fn new(cfg: CoordinatorConfig) -> anyhow::Result<Self> {
+    pub fn new(cfg: CoordinatorConfig) -> eyre::Result<Self> {
         let retry_wait_duration = Duration::from_secs(cfg.retry_wait_time_sec);
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(retry_wait_duration / 2, retry_wait_duration)
@@ -34,8 +34,8 @@ impl Api {
         })
     }
 
-    fn build_url(&self, method: &str) -> anyhow::Result<Url> {
-        self.base_url.join(method).map_err(|e| anyhow::anyhow!(e))
+    fn build_url(&self, method: &str) -> eyre::Result<Url> {
+        self.base_url.join(method).map_err(|e| eyre::eyre!(e))
     }
 
     #[instrument(target = "coordinator_client", skip(self, req, token), level = Level::DEBUG)]
@@ -44,7 +44,7 @@ impl Api {
         method: &str,
         req: &Req,
         token: &String,
-    ) -> anyhow::Result<Resp>
+    ) -> eyre::Result<Resp>
     where
         Req: ?Sized + Serialize,
         Resp: serde::de::DeserializeOwned,
@@ -66,7 +66,7 @@ impl Api {
             .await?;
 
         if response.status() != http::status::StatusCode::OK {
-            anyhow::bail!(
+            eyre::bail!(
                 "[coordinator client], {method}, status not ok: {}",
                 response.status()
             )
@@ -76,10 +76,10 @@ impl Api {
 
         info!("received response");
         trace!(response_body = %response_body);
-        serde_json::from_str(&response_body).map_err(|e| anyhow::anyhow!(e))
+        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
     }
 
-    pub async fn challenge(&self) -> anyhow::Result<Response<ChallengeResponseData>> {
+    pub async fn challenge(&self) -> eyre::Result<Response<ChallengeResponseData>> {
         let method = "/coordinator/v1/challenge";
         let url = self.build_url(method)?;
 
@@ -93,14 +93,14 @@ impl Api {
 
         let response_body = response.text().await?;
 
-        serde_json::from_str(&response_body).map_err(|e| anyhow::anyhow!(e))
+        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
     }
 
     pub async fn login(
         &self,
         req: &LoginRequest,
         token: &String,
-    ) -> anyhow::Result<Response<LoginResponseData>> {
+    ) -> eyre::Result<Response<LoginResponseData>> {
         let method = "/coordinator/v1/login";
         self.post_with_token(method, req, token).await
     }
@@ -109,7 +109,7 @@ impl Api {
         &self,
         req: &GetTaskRequest,
         token: &String,
-    ) -> anyhow::Result<Response<GetTaskResponseData>> {
+    ) -> eyre::Result<Response<GetTaskResponseData>> {
         let method = "/coordinator/v1/get_task";
         if self.send_timeout < Duration::from_secs(600) {
             tracing::warn!(
@@ -125,7 +125,7 @@ impl Api {
         &self,
         req: &SubmitProofRequest,
         token: &String,
-    ) -> anyhow::Result<Response<SubmitProofResponseData>> {
+    ) -> eyre::Result<Response<SubmitProofResponseData>> {
         let method = "/coordinator/v1/submit_proof";
         self.post_with_token(method, req, token).await
     }

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -38,7 +38,7 @@ impl Api {
         self.base_url.join(method).map_err(|e| eyre::eyre!(e))
     }
 
-    #[instrument(target = "coordinator_client", skip(self, req, token), level = Level::DEBUG)]
+    #[instrument(skip(self, req, token), level = Level::DEBUG)]
     async fn post_with_token<Req, Resp>(
         &self,
         method: &str,
@@ -53,7 +53,7 @@ impl Api {
         let request_body = serde_json::to_string(req)?;
         let size = request_body.len();
 
-        info!("sent request");
+        debug!("sent request");
         trace!(token = %token, request_body = %request_body, size = %size);
         let response = self
             .client
@@ -74,7 +74,7 @@ impl Api {
 
         let response_body = response.text().await?;
 
-        info!("received response");
+        debug!("received response");
         trace!(response_body = %response_body);
         serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
     }

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -43,71 +43,12 @@ impl Api {
         response.into_result().context("challenge request failed")
     }
 
-    #[instrument(skip(self, req, token), level = Level::DEBUG)]
-    async fn post_with_token<Req, Resp>(
-        &self,
-        method: &str,
-        req: &Req,
-        token: &String,
-    ) -> eyre::Result<Resp>
-    where
-        Req: ?Sized + Serialize,
-        Resp: serde::de::DeserializeOwned,
-    {
-        let url = self.build_url(method)?;
-        let request_body = serde_json::to_string(req)?;
-        let size = request_body.len();
-
-        debug!("sent request");
-        trace!(token = %token, request_body = %request_body, size = %size);
-        let response = self
-            .client
-            .post(url)
-            .header(CONTENT_TYPE, "application/json")
-            .bearer_auth(token)
-            .body(request_body)
-            .timeout(self.send_timeout)
-            .send()
+    pub async fn login(&self, req: &LoginRequest<'_>, token: &str) -> eyre::Result<LoginResponse> {
+        const PATH: &str = "/coordinator/v1/login";
+        let response: Response<LoginResponse> = self
+            .request(Method::POST, PATH, Some(req), Some(token))
             .await?;
-
-        if response.status() != http::status::StatusCode::OK {
-            eyre::bail!(
-                "[coordinator client], {method}, status not ok: {}",
-                response.status()
-            )
-        }
-
-        let response_body = response.text().await?;
-
-        debug!("received response");
-        trace!(response_body = %response_body);
-        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
-    }
-
-    pub async fn challenge(&self) -> eyre::Result<Response<ChallengeResponseData>> {
-        let method = "/coordinator/v1/challenge";
-        let url = self.build_url(method)?;
-
-        let response = self
-            .client
-            .get(url)
-            .header(CONTENT_TYPE, "application/json")
-            .timeout(self.send_timeout)
-            .send()
-            .await?;
-
-        let response_body = response.text().await?;
-
-        serde_json::from_str(&response_body).map_err(|e| eyre::eyre!(e))
-    }
-
-    pub async fn login(
-        &self,
-        req: &LoginRequest,
-        token: &String,
-    ) -> eyre::Result<Response<LoginResponseData>> {
-        let method = "/coordinator/v1/login";
-        self.post_with_token(method, req, token).await
+        response.into_result().context("login failed")
     }
 
     pub async fn get_task(

--- a/src/coordinator_handler/api.rs
+++ b/src/coordinator_handler/api.rs
@@ -8,6 +8,7 @@ use reqwest::{header::CONTENT_TYPE, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::Serialize;
+use tracing::Level;
 
 pub struct Api {
     pub base_url: Url,
@@ -37,6 +38,7 @@ impl Api {
         self.base_url.join(method).map_err(|e| anyhow::anyhow!(e))
     }
 
+    #[instrument(target = "coordinator_client", skip(self, req, token), level = Level::DEBUG)]
     async fn post_with_token<Req, Resp>(
         &self,
         method: &str,
@@ -51,8 +53,8 @@ impl Api {
         let request_body = serde_json::to_string(req)?;
         let size = request_body.len();
 
-        log::info!("[coordinator client], {method}, sent request");
-        log::debug!("[coordinator client], {method}, request: {request_body}, token: {token}, request size: {size}");
+        info!("sent request");
+        trace!(token = %token, request_body = %request_body, size = %size);
         let response = self
             .client
             .post(url)
@@ -72,8 +74,8 @@ impl Api {
 
         let response_body = response.text().await?;
 
-        log::info!("[coordinator client], {method}, received response");
-        log::debug!("[coordinator client], {method}, response: {response_body}");
+        info!("received response");
+        trace!(response_body = %response_body);
         serde_json::from_str(&response_body).map_err(|e| anyhow::anyhow!(e))
     }
 
@@ -109,7 +111,7 @@ impl Api {
         token: &String,
     ) -> anyhow::Result<Response<GetTaskResponseData>> {
         let method = "/coordinator/v1/get_task";
-        if self.send_timeout < core::time::Duration::from_secs(600) {
+        if self.send_timeout < Duration::from_secs(600) {
             tracing::warn!(
                 "get_task API is time-consuming, timeout setting is too low ({}), set it to more than 600s",
                 self.send_timeout.as_secs(),

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -1,6 +1,6 @@
 use super::{
-    GetTaskRequest, GetTaskResponseData, KeySigner, LoginMessage, LoginRequest, ProverType,
-    Response, SubmitProofRequest, SubmitProofResponseData, api::Api,
+    GetTaskRequest, GetTaskResponse, KeySigner, LoginMessage, LoginRequest, ProverType,
+    SubmitProofRequest, api::Api,
 };
 use crate::{config::CoordinatorConfig, prover::ProverProviderType, utils::VERSION};
 use std::borrow::Cow;
@@ -44,14 +44,14 @@ impl CoordinatorClient {
     }
     pub async fn token(&self) -> eyre::Result<Arc<str>> {
         let mutex = self.get_lazy_init_mutex().await?;
-        let guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // handle poisoned lock
+        let guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // ignore poisoned lock
         Ok(guard.clone())
     }
 
     pub async fn get_task(
         &self,
         req: &GetTaskRequest<'_>,
-    ) -> eyre::Result<Option<GetTaskResponseData>> {
+    ) -> eyre::Result<Option<GetTaskResponse>> {
         let response = self.api.get_task(req, &self.token().await?).await?;
 
         let response = if response.is_jwt_token_expired() {
@@ -67,18 +67,16 @@ impl CoordinatorClient {
         Ok(Some(response.into_result()?))
     }
 
-    pub async fn submit_proof(
-        &self,
-        req: &SubmitProofRequest<'_>,
-    ) -> eyre::Result<Response<SubmitProofResponseData>> {
+    pub async fn submit_proof(&self, req: &SubmitProofRequest<'_>) -> eyre::Result<()> {
         let response = self.api.submit_proof(req, &self.token().await?).await?;
 
         if response.is_jwt_token_expired() {
             let token = self.refresh_token().await?;
-            self.api.submit_proof(req, &token).await
+            self.api.submit_proof(req, &token).await?.into_result()?;
         } else {
-            Ok(response)
+            response.into_result()?;
         }
+        Ok(())
     }
 
     /// Refresh the jwt token for authentication.
@@ -94,7 +92,7 @@ impl CoordinatorClient {
             &self.key_signer,
         )
         .await?;
-        let mut guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // handle poisoned lock
+        let mut guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // ignore poisoned lock
         *guard = token.clone();
 
         Ok(token)

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -1,24 +1,29 @@
 use super::{
-    api::Api, error::ErrorCode, GetTaskRequest, GetTaskResponseData, KeySigner, LoginMessage,
-    LoginRequest, ProverType, Response, SubmitProofRequest, SubmitProofResponseData,
+    GetTaskRequest, GetTaskResponseData, KeySigner, LoginMessage, LoginRequest, ProverType,
+    Response, SubmitProofRequest, SubmitProofResponseData, api::Api,
 };
-use crate::{config::CoordinatorConfig, prover::ProverProviderType, utils::get_version};
-use tokio::sync::{Mutex, MutexGuard};
+use crate::{config::CoordinatorConfig, prover::ProverProviderType, utils::VERSION};
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tokio::sync::OnceCell;
 
 pub struct CoordinatorClient {
-    prover_types: Vec<ProverType>,
-    vks: Vec<String>,
     pub prover_name: String,
     pub prover_provider_type: ProverProviderType,
     pub key_signer: KeySigner,
+    prover_types: Vec<ProverType>,
+    vks: Vec<String>,
     api: Api,
-    token: Mutex<Option<String>>,
+    suppress_empty_task_errors: bool,
+    token: OnceCell<Mutex<Arc<str>>>,
 }
 
 impl CoordinatorClient {
     pub fn new(
         cfg: CoordinatorConfig,
         prover_types: Vec<ProverType>,
+        suppress_empty_task_errors: bool,
         vks: Vec<String>,
         prover_name: String,
         prover_provider_type: ProverProviderType,
@@ -32,121 +37,121 @@ impl CoordinatorClient {
             prover_provider_type,
             key_signer,
             api,
-            token: Mutex::new(None),
+            suppress_empty_task_errors,
+            token: OnceCell::new(),
         };
         Ok(client)
+    }
+    pub async fn token(&self) -> eyre::Result<Arc<str>> {
+        let mutex = self.get_lazy_init_mutex().await?;
+        let guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // handle poisoned lock
+        Ok(guard.clone())
     }
 
     pub async fn get_task(
         &self,
-        req: &GetTaskRequest,
-    ) -> eyre::Result<Response<GetTaskResponseData>> {
-        let token = self.get_token(false).await?;
-        let response = self.api.get_task(req, &token).await?;
+        req: &GetTaskRequest<'_>,
+    ) -> eyre::Result<Option<GetTaskResponseData>> {
+        let response = self.api.get_task(req, &self.token().await?).await?;
 
-        if response.errcode == ErrorCode::ErrJWTTokenExpired {
-            let token = self.get_token(true).await?;
-            self.api.get_task(req, &token).await
+        let response = if response.is_jwt_token_expired() {
+            let token = self.refresh_token().await?;
+            self.api.get_task(req, &token).await?
         } else {
-            Ok(response)
+            response
+        };
+
+        if response.is_empty_task_error() && self.suppress_empty_task_errors {
+            return Ok(None);
         }
+        Ok(Some(response.into_result()?))
     }
 
     pub async fn submit_proof(
         &self,
-        req: &SubmitProofRequest,
+        req: &SubmitProofRequest<'_>,
     ) -> eyre::Result<Response<SubmitProofResponseData>> {
-        let token = self.get_token(false).await?;
-        let response = self.api.submit_proof(req, &token).await?;
+        let response = self.api.submit_proof(req, &self.token().await?).await?;
 
-        if response.errcode == ErrorCode::ErrJWTTokenExpired {
-            let token = self.get_token(true).await?;
+        if response.is_jwt_token_expired() {
+            let token = self.refresh_token().await?;
             self.api.submit_proof(req, &token).await
         } else {
             Ok(response)
         }
     }
 
-    /// Retrieves a token for authentication, optionally forcing a re-login.
-    ///
-    /// This function attempts to get the stored token if `force_relogin` is set to `false`.
-    ///
-    /// If the token is expired, `force_relogin` is set to `true`, or a login was never performed
-    /// before, it will authenticate and fetch a new token.
-    pub async fn get_token(&self, force_relogin: bool) -> eyre::Result<String> {
-        let token_guard = self.token.lock().await;
+    /// Refresh the jwt token for authentication.
+    pub async fn refresh_token(&self) -> eyre::Result<Arc<str>> {
+        let mutex = self.get_lazy_init_mutex().await?;
 
-        match *token_guard {
-            Some(ref token) if !force_relogin => return Ok(token.to_string()),
-            _ => (),
-        }
-
-        self.login(token_guard).await
-    }
-
-    async fn login(
-        &self,
-        mut token_guard: MutexGuard<'_, Option<String>>,
-    ) -> eyre::Result<String> {
-        let challenge_response = self
-            .api
-            .challenge()
-            .await
-            .map_err(|e| eyre::eyre!("Failed to request a challenge: {e}"))?;
-
-        if challenge_response.errcode != ErrorCode::Success {
-            eyre::bail!(
-                "Challenge request failed with {:?} {}",
-                challenge_response.errcode,
-                challenge_response.errmsg
-            );
-        }
-
-        let login_response_data = challenge_response
-            .data
-            .as_ref()
-            .ok_or_else(|| eyre::eyre!("Missing challenge token"))?;
-
-        let login_message = LoginMessage {
-            challenge: login_response_data.token.clone(),
-            prover_version: get_version().to_string(),
-            prover_name: self.prover_name.clone(),
-            prover_provider_type: self.prover_provider_type,
-            prover_types: self.prover_types.clone(),
-            vks: self.vks.clone(),
-        };
-
-        let buffer = rlp::encode(&login_message);
-        let signature = self
-            .key_signer
-            .sign_buffer(&buffer)
-            .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))?;
-
-        let login_request = LoginRequest {
-            message: login_message,
-            public_key: self.key_signer.get_public_key(),
-            signature,
-        };
-        let login_response = self
-            .api
-            .login(&login_request, &login_response_data.token)
-            .await
-            .map_err(|e| eyre::eyre!("Failed to login: {e}"))?;
-
-        if login_response.errcode != ErrorCode::Success {
-            eyre::bail!(
-                "Login request failed with {:?} {}",
-                login_response.errcode,
-                login_response.errmsg
-            );
-        }
-        let token = login_response
-            .data
-            .map(|r| r.token)
-            .ok_or_else(|| eyre::eyre!("Empty data in response, lack of login"))?;
-
-        *token_guard = Some(token.clone());
+        let token = refresh_token(
+            &self.api,
+            &self.prover_name,
+            self.prover_provider_type,
+            &self.prover_types,
+            &self.vks,
+            &self.key_signer,
+        )
+        .await?;
+        let mut guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // handle poisoned lock
+        *guard = token.clone();
 
         Ok(token)
     }
+
+    async fn get_lazy_init_mutex(&self) -> eyre::Result<&Mutex<Arc<str>>> {
+        self.token
+            .get_or_try_init::<eyre::Report, _, _>(|| async {
+                let token = refresh_token(
+                    &self.api,
+                    &self.prover_name,
+                    self.prover_provider_type,
+                    &self.prover_types,
+                    &self.vks,
+                    &self.key_signer,
+                )
+                .await?;
+                Ok(Mutex::new(token))
+            })
+            .await
+    }
+}
+
+async fn refresh_token(
+    api: &Api,
+    prover_name: &str,
+    prover_provider_type: ProverProviderType,
+    prover_types: &[ProverType],
+    vks: &[String],
+    key_signer: &KeySigner,
+) -> eyre::Result<Arc<str>> {
+    // login and get new token
+    let challenge = api.challenge().await?;
+
+    let login_message = LoginMessage {
+        challenge: Cow::Borrowed(&challenge.token),
+        prover_version: VERSION.into(),
+        prover_name: Cow::Borrowed(prover_name),
+        prover_provider_type,
+        prover_types: prover_types.into(),
+        vks: vks.to_vec(),
+    };
+    let buffer = alloy_rlp::encode(&login_message);
+    let signature = key_signer
+        .sign_buffer(&buffer)
+        .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))?;
+
+    let response = api
+        .login(
+            &LoginRequest {
+                message: login_message,
+                public_key: key_signer.get_public_key().into(),
+                signature: signature.into(),
+            },
+            &challenge.token,
+        )
+        .await?;
+
+    Ok(Arc::from(response.token))
 }

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -1,6 +1,6 @@
 use super::{
     GetTaskRequest, GetTaskResponse, KeySigner, LoginMessage, LoginRequest, ProverType,
-    SubmitProofRequest, api::Api,
+    ProverTypes, SubmitProofRequest, api::Api,
 };
 use crate::{config::CoordinatorConfig, prover::ProverProviderType, utils::VERSION};
 use tokio::sync::Mutex;
@@ -88,7 +88,7 @@ impl CoordinatorClient {
                 prover_version: VERSION,
                 prover_name: &self.prover_name,
                 prover_provider_type: self.prover_provider_type,
-                prover_types: &self.prover_types,
+                prover_types: ProverTypes(&self.prover_types),
                 vks: &self.vks,
             };
             let buffer = alloy_rlp::encode(&login_message);

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -23,7 +23,7 @@ impl CoordinatorClient {
         prover_name: String,
         prover_provider_type: ProverProviderType,
         key_signer: KeySigner,
-    ) -> anyhow::Result<Self> {
+    ) -> eyre::Result<Self> {
         let api = Api::new(cfg)?;
         let client = Self {
             prover_types,
@@ -40,7 +40,7 @@ impl CoordinatorClient {
     pub async fn get_task(
         &self,
         req: &GetTaskRequest,
-    ) -> anyhow::Result<Response<GetTaskResponseData>> {
+    ) -> eyre::Result<Response<GetTaskResponseData>> {
         let token = self.get_token(false).await?;
         let response = self.api.get_task(req, &token).await?;
 
@@ -55,7 +55,7 @@ impl CoordinatorClient {
     pub async fn submit_proof(
         &self,
         req: &SubmitProofRequest,
-    ) -> anyhow::Result<Response<SubmitProofResponseData>> {
+    ) -> eyre::Result<Response<SubmitProofResponseData>> {
         let token = self.get_token(false).await?;
         let response = self.api.submit_proof(req, &token).await?;
 
@@ -73,7 +73,7 @@ impl CoordinatorClient {
     ///
     /// If the token is expired, `force_relogin` is set to `true`, or a login was never performed
     /// before, it will authenticate and fetch a new token.
-    pub async fn get_token(&self, force_relogin: bool) -> anyhow::Result<String> {
+    pub async fn get_token(&self, force_relogin: bool) -> eyre::Result<String> {
         let token_guard = self.token.lock().await;
 
         match *token_guard {
@@ -87,15 +87,15 @@ impl CoordinatorClient {
     async fn login(
         &self,
         mut token_guard: MutexGuard<'_, Option<String>>,
-    ) -> anyhow::Result<String> {
+    ) -> eyre::Result<String> {
         let challenge_response = self
             .api
             .challenge()
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to request a challenge: {e}"))?;
+            .map_err(|e| eyre::eyre!("Failed to request a challenge: {e}"))?;
 
         if challenge_response.errcode != ErrorCode::Success {
-            anyhow::bail!(
+            eyre::bail!(
                 "Challenge request failed with {:?} {}",
                 challenge_response.errcode,
                 challenge_response.errmsg
@@ -105,7 +105,7 @@ impl CoordinatorClient {
         let login_response_data = challenge_response
             .data
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Missing challenge token"))?;
+            .ok_or_else(|| eyre::eyre!("Missing challenge token"))?;
 
         let login_message = LoginMessage {
             challenge: login_response_data.token.clone(),
@@ -120,7 +120,7 @@ impl CoordinatorClient {
         let signature = self
             .key_signer
             .sign_buffer(&buffer)
-            .map_err(|e| anyhow::anyhow!("Failed to sign the login message: {e}"))?;
+            .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))?;
 
         let login_request = LoginRequest {
             message: login_message,
@@ -131,10 +131,10 @@ impl CoordinatorClient {
             .api
             .login(&login_request, &login_response_data.token)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to login: {e}"))?;
+            .map_err(|e| eyre::eyre!("Failed to login: {e}"))?;
 
         if login_response.errcode != ErrorCode::Success {
-            anyhow::bail!(
+            eyre::bail!(
                 "Login request failed with {:?} {}",
                 login_response.errcode,
                 login_response.errmsg
@@ -143,7 +143,7 @@ impl CoordinatorClient {
         let token = login_response
             .data
             .map(|r| r.token)
-            .ok_or_else(|| anyhow::anyhow!("Empty data in response, lack of login"))?;
+            .ok_or_else(|| eyre::eyre!("Empty data in response, lack of login"))?;
 
         *token_guard = Some(token.clone());
 

--- a/src/coordinator_handler/coordinator_client.rs
+++ b/src/coordinator_handler/coordinator_client.rs
@@ -3,10 +3,7 @@ use super::{
     SubmitProofRequest, api::Api,
 };
 use crate::{config::CoordinatorConfig, prover::ProverProviderType, utils::VERSION};
-use std::borrow::Cow;
-use std::sync::Arc;
-use std::sync::Mutex;
-use tokio::sync::OnceCell;
+use tokio::sync::Mutex;
 
 pub struct CoordinatorClient {
     pub prover_name: String,
@@ -16,7 +13,7 @@ pub struct CoordinatorClient {
     vks: Vec<String>,
     api: Api,
     suppress_empty_task_errors: bool,
-    token: OnceCell<Mutex<Arc<str>>>,
+    token: Mutex<String>,
 }
 
 impl CoordinatorClient {
@@ -38,21 +35,19 @@ impl CoordinatorClient {
             key_signer,
             api,
             suppress_empty_task_errors,
-            token: OnceCell::new(),
+            token: Default::default(),
         };
         Ok(client)
-    }
-    pub async fn token(&self) -> eyre::Result<Arc<str>> {
-        let mutex = self.get_lazy_init_mutex().await?;
-        let guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // ignore poisoned lock
-        Ok(guard.clone())
     }
 
     pub async fn get_task(
         &self,
         req: &GetTaskRequest<'_>,
     ) -> eyre::Result<Option<GetTaskResponse>> {
-        let response = self.api.get_task(req, &self.token().await?).await?;
+        let response = {
+            let token = self.token.lock().await;
+            self.api.get_task(req, &token).await?
+        };
 
         let response = if response.is_jwt_token_expired() {
             let token = self.refresh_token().await?;
@@ -68,7 +63,10 @@ impl CoordinatorClient {
     }
 
     pub async fn submit_proof(&self, req: &SubmitProofRequest<'_>) -> eyre::Result<()> {
-        let response = self.api.submit_proof(req, &self.token().await?).await?;
+        let response = {
+            let token = self.token.lock().await;
+            self.api.submit_proof(req, &token).await?
+        };
 
         if response.is_jwt_token_expired() {
             let token = self.refresh_token().await?;
@@ -80,76 +78,43 @@ impl CoordinatorClient {
     }
 
     /// Refresh the jwt token for authentication.
-    pub async fn refresh_token(&self) -> eyre::Result<Arc<str>> {
-        let mutex = self.get_lazy_init_mutex().await?;
+    pub async fn refresh_token(&self) -> eyre::Result<String> {
+        let token = {
+            // login and get new token
+            let challenge = self.api.challenge().await?;
 
-        let token = refresh_token(
-            &self.api,
-            &self.prover_name,
-            self.prover_provider_type,
-            &self.prover_types,
-            &self.vks,
-            &self.key_signer,
-        )
-        .await?;
-        let mut guard = mutex.lock().unwrap_or_else(|e| e.into_inner()); // ignore poisoned lock
+            let login_message = LoginMessage {
+                challenge: &challenge.token,
+                prover_version: VERSION,
+                prover_name: &self.prover_name,
+                prover_provider_type: self.prover_provider_type,
+                prover_types: &self.prover_types,
+                vks: &self.vks,
+            };
+            let buffer = alloy_rlp::encode(&login_message);
+            let signature = self
+                .key_signer
+                .sign_buffer(&buffer)
+                .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))?;
+
+            let response = self
+                .api
+                .login(
+                    &LoginRequest {
+                        message: login_message,
+                        public_key: &self.key_signer.get_public_key(),
+                        signature: &signature,
+                    },
+                    &challenge.token,
+                )
+                .await?;
+
+            response.token
+        };
+
+        let mut guard = self.token.lock().await; // ignore poisoned lock
         *guard = token.clone();
 
         Ok(token)
     }
-
-    async fn get_lazy_init_mutex(&self) -> eyre::Result<&Mutex<Arc<str>>> {
-        self.token
-            .get_or_try_init::<eyre::Report, _, _>(|| async {
-                let token = refresh_token(
-                    &self.api,
-                    &self.prover_name,
-                    self.prover_provider_type,
-                    &self.prover_types,
-                    &self.vks,
-                    &self.key_signer,
-                )
-                .await?;
-                Ok(Mutex::new(token))
-            })
-            .await
-    }
-}
-
-async fn refresh_token(
-    api: &Api,
-    prover_name: &str,
-    prover_provider_type: ProverProviderType,
-    prover_types: &[ProverType],
-    vks: &[String],
-    key_signer: &KeySigner,
-) -> eyre::Result<Arc<str>> {
-    // login and get new token
-    let challenge = api.challenge().await?;
-
-    let login_message = LoginMessage {
-        challenge: Cow::Borrowed(&challenge.token),
-        prover_version: VERSION.into(),
-        prover_name: Cow::Borrowed(prover_name),
-        prover_provider_type,
-        prover_types: prover_types.into(),
-        vks: vks.to_vec(),
-    };
-    let buffer = alloy_rlp::encode(&login_message);
-    let signature = key_signer
-        .sign_buffer(&buffer)
-        .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))?;
-
-    let response = api
-        .login(
-            &LoginRequest {
-                message: login_message,
-                public_key: key_signer.get_public_key().into(),
-                signature: signature.into(),
-            },
-            &challenge.token,
-        )
-        .await?;
-
-    Ok(Arc::from(response.token))
 }

--- a/src/coordinator_handler/error.rs
+++ b/src/coordinator_handler/error.rs
@@ -1,22 +1,22 @@
 use serde::{Deserialize, Deserializer};
-use std::fmt;
+use strum::EnumIs;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, EnumIs)]
 pub enum ErrorCode {
     Success,
     InternalServerError,
 
-    ErrProverStatsAPIParameterInvalidNo,
-    ErrProverStatsAPIProverTaskFailure,
-    ErrProverStatsAPIProverTotalRewardFailure,
+    ProverStatsAPIParameterInvalidNo,
+    ProverStatsAPIProverTaskFailure,
+    ProverStatsAPIProverTotalRewardFailure,
 
-    ErrCoordinatorParameterInvalidNo,
-    ErrCoordinatorGetTaskFailure,
-    ErrCoordinatorHandleZkProofFailure,
-    ErrCoordinatorEmptyProofData,
+    CoordinatorParameterInvalidNo,
+    CoordinatorGetTaskFailure,
+    CoordinatorHandleZkProofFailure,
+    CoordinatorEmptyProofData,
 
-    ErrJWTCommonErr,
-    ErrJWTTokenExpired,
+    JWTCommonErr,
+    JWTTokenExpired,
 
     Undefined(i32),
 }
@@ -26,15 +26,15 @@ impl ErrorCode {
         match v {
             0 => ErrorCode::Success,
             500 => ErrorCode::InternalServerError,
-            10001 => ErrorCode::ErrProverStatsAPIParameterInvalidNo,
-            10002 => ErrorCode::ErrProverStatsAPIProverTaskFailure,
-            10003 => ErrorCode::ErrProverStatsAPIProverTotalRewardFailure,
-            20001 => ErrorCode::ErrCoordinatorParameterInvalidNo,
-            20002 => ErrorCode::ErrCoordinatorGetTaskFailure,
-            20003 => ErrorCode::ErrCoordinatorHandleZkProofFailure,
-            20004 => ErrorCode::ErrCoordinatorEmptyProofData,
-            50000 => ErrorCode::ErrJWTCommonErr,
-            50001 => ErrorCode::ErrJWTTokenExpired,
+            10001 => ErrorCode::ProverStatsAPIParameterInvalidNo,
+            10002 => ErrorCode::ProverStatsAPIProverTaskFailure,
+            10003 => ErrorCode::ProverStatsAPIProverTotalRewardFailure,
+            20001 => ErrorCode::CoordinatorParameterInvalidNo,
+            20002 => ErrorCode::CoordinatorGetTaskFailure,
+            20003 => ErrorCode::CoordinatorHandleZkProofFailure,
+            20004 => ErrorCode::CoordinatorEmptyProofData,
+            50000 => ErrorCode::JWTCommonErr,
+            50001 => ErrorCode::JWTTokenExpired,
             _ => {
                 error!("get unexpected error code from coordinator: {v}");
                 ErrorCode::Undefined(v)
@@ -50,16 +50,5 @@ impl<'de> Deserialize<'de> for ErrorCode {
     {
         let v: i32 = i32::deserialize(deserializer)?;
         Ok(ErrorCode::from_i32(v))
-    }
-}
-
-// ====================================================
-
-#[derive(Debug, Clone)]
-pub struct ProofStatusNotOKError;
-
-impl fmt::Display for ProofStatusNotOKError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "proof status not ok")
     }
 }

--- a/src/coordinator_handler/error.rs
+++ b/src/coordinator_handler/error.rs
@@ -36,7 +36,7 @@ impl ErrorCode {
             50000 => ErrorCode::ErrJWTCommonErr,
             50001 => ErrorCode::ErrJWTTokenExpired,
             _ => {
-                log::error!("get unexpected error code from coordinator: {v}");
+                error!("get unexpected error code from coordinator: {v}");
                 ErrorCode::Undefined(v)
             }
         }

--- a/src/coordinator_handler/key_signer.rs
+++ b/src/coordinator_handler/key_signer.rs
@@ -1,8 +1,8 @@
 use ethers_core::{
     k256::{
-        ecdsa::{signature::hazmat::PrehashSigner, RecoveryId, Signature, SigningKey},
-        elliptic_curve::{sec1::ToEncodedPoint, FieldBytes},
         PublicKey, Secp256k1, SecretKey,
+        ecdsa::{RecoveryId, Signature, SigningKey, signature::hazmat::PrehashSigner},
+        elliptic_curve::{FieldBytes, sec1::ToEncodedPoint},
     },
     types::Signature as EthSignature,
     types::{H256, U256},

--- a/src/coordinator_handler/key_signer.rs
+++ b/src/coordinator_handler/key_signer.rs
@@ -17,17 +17,17 @@ use tiny_keccak::{Hasher, Keccak};
 
 const DEFAULT_KEY_SIZE: usize = 32usize;
 
-fn read_key_from_disk(key_path: &PathBuf) -> anyhow::Result<Vec<u8>> {
+fn read_key_from_disk(key_path: &PathBuf) -> eyre::Result<Vec<u8>> {
     let mut file = File::open(key_path)?;
     let mut content = String::new();
     file.read_to_string(&mut content)?;
     Ok(hex::decode(content)?)
 }
 
-fn gen_key_save_to_disk(key_path: &PathBuf) -> anyhow::Result<Vec<u8>> {
+fn gen_key_save_to_disk(key_path: &PathBuf) -> eyre::Result<Vec<u8>> {
     // Generate a random private key.
     let mut secret = vec![0u8; DEFAULT_KEY_SIZE];
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     rng.fill_bytes(secret.as_mut_slice());
 
     let content = hex::encode(secret.clone());
@@ -44,7 +44,7 @@ pub struct KeySigner {
 }
 
 impl KeySigner {
-    pub fn new(key_path: &PathBuf) -> anyhow::Result<Self> {
+    pub fn new(key_path: &PathBuf) -> eyre::Result<Self> {
         let secret = match read_key_from_disk(key_path) {
             Ok(secret) => secret,
             Err(_) => gen_key_save_to_disk(key_path)?,
@@ -58,7 +58,7 @@ impl KeySigner {
         })
     }
 
-    pub fn new_from_secret_key(secret_key: &str) -> anyhow::Result<Self> {
+    pub fn new_from_secret_key(secret_key: &str) -> eyre::Result<Self> {
         let secret = hex::decode(secret_key).unwrap();
         let secret_key = SecretKey::from_bytes(secret.as_slice().into())?;
         let signing_key = SigningKey::from(secret_key.clone());
@@ -74,7 +74,7 @@ impl KeySigner {
     }
 
     /// Signs the provided hash.
-    pub fn sign_hash(&self, hash: H256) -> anyhow::Result<EthSignature> {
+    pub fn sign_hash(&self, hash: H256) -> eyre::Result<EthSignature> {
         let signing_key = &self.signing_key as &dyn PrehashSigner<(Signature, RecoveryId)>;
         let (recoverable_sig, recovery_id) = signing_key.sign_prehash(hash.as_ref())?;
 
@@ -82,13 +82,15 @@ impl KeySigner {
 
         let r_bytes: FieldBytes<Secp256k1> = recoverable_sig.r().into();
         let s_bytes: FieldBytes<Secp256k1> = recoverable_sig.s().into();
+        #[allow(deprecated)]
         let r = U256::from_big_endian(r_bytes.as_slice());
+        #[allow(deprecated)]
         let s = U256::from_big_endian(s_bytes.as_slice());
 
         Ok(EthSignature { r, s, v })
     }
 
-    pub fn sign_buffer<T>(&self, buffer: &T) -> anyhow::Result<String>
+    pub fn sign_buffer<T>(&self, buffer: &T) -> eyre::Result<String>
     where
         T: AsRef<[u8]>,
     {

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -62,6 +62,13 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Response<T> {
         if helper.errcode == ErrorCode::Success {
             if let Some(data) = helper.data {
                 Ok(Response::Ok(data))
+            } else if size_of::<T>() == 0 {
+                // Special handling for zero-sized types, e.g. Reposnse<()>
+                let zst: T = unsafe {
+                    // SAFETY: It's always safe to synthesizing ZST
+                    std::mem::zeroed()
+                };
+                return Ok(Response::Ok(zst));
             } else {
                 Err(serde::de::Error::custom(
                     "Expected data field for successful response",

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -176,7 +176,7 @@ pub struct LoginMessage<'a> {
     pub prover_version: &'a str,
     pub prover_name: &'a str,
     pub prover_provider_type: ProverProviderType,
-    pub prover_types: &'a Vec<ProverType>,
+    pub prover_types: ProverTypes<'a>,
     pub vks: &'a Vec<String>,
 }
 
@@ -292,7 +292,7 @@ mod tests {
             prover_version: "v4.4.45-37af5ef5-38a68e2-1c5093c".into(),
             prover_name: "test".into(),
             prover_provider_type: ProverProviderType::Internal,
-            prover_types: &prover_types,
+            prover_types: ProverTypes(&prover_types),
             vks: &vks,
         };
 

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -5,7 +5,6 @@ use alloy_rlp::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr as DeserializeRepr, Serialize_repr as SerializeRepr};
-use std::borrow::Cow;
 use std::fmt;
 use strum::{EnumIs, FromRepr};
 
@@ -68,7 +67,7 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Response<T> {
                     // SAFETY: It's always safe to synthesizing ZST
                     std::mem::zeroed()
                 };
-                return Ok(Response::Ok(zst));
+                Ok(Response::Ok(zst))
             } else {
                 Err(serde::de::Error::custom(
                     "Expected data field for successful response",
@@ -143,14 +142,8 @@ impl Decodable for ProverType {
 
 /// The ProverType in go side is a type alias of uint8
 /// A uint8 slice is treated as a string when doing the rlp encoding
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProverTypes<'a>(Cow<'a, [ProverType]>);
-
-impl<'a, T: Into<Cow<'a, [ProverType]>>> From<T> for ProverTypes<'a> {
-    fn from(value: T) -> Self {
-        ProverTypes(value.into())
-    }
-}
+#[derive(Debug, Clone, Serialize)]
+pub struct ProverTypes<'a>(pub &'a [ProverType]);
 
 /// See implementation of [`Encodable`] for [u8]
 impl Encodable for ProverTypes<'_> {
@@ -179,19 +172,19 @@ impl Encodable for ProverTypes<'_> {
 
 #[derive(Debug, Clone, Serialize, RlpEncodable)]
 pub struct LoginMessage<'a> {
-    pub challenge: Cow<'a, str>,
-    pub prover_version: Cow<'a, str>,
-    pub prover_name: Cow<'a, str>,
+    pub challenge: &'a str,
+    pub prover_version: &'a str,
+    pub prover_name: &'a str,
     pub prover_provider_type: ProverProviderType,
-    pub prover_types: ProverTypes<'a>,
-    pub vks: Vec<String>,
+    pub prover_types: &'a Vec<ProverType>,
+    pub vks: &'a Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LoginRequest<'a> {
     pub message: LoginMessage<'a>,
-    pub public_key: Cow<'a, str>,
-    pub signature: Cow<'a, str>,
+    pub public_key: &'a str,
+    pub signature: &'a str,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -207,7 +200,7 @@ pub struct GetTaskRequest<'a> {
     pub task_types: Vec<ProofType>,
     pub prover_height: Option<u64>,
     pub universal: bool,
-    pub task_id: Option<Cow<'a, str>>,
+    pub task_id: Option<&'a str>,
 }
 
 #[derive(Default, Clone, Serialize, Deserialize)]
@@ -221,13 +214,13 @@ pub struct GetTaskResponse {
 
 #[derive(Debug, Clone, Serialize)] // TODO: Default?
 pub struct SubmitProofRequest<'a> {
-    pub uuid: Cow<'a, str>,
-    pub task_id: Cow<'a, str>,
+    pub uuid: &'a str,
+    pub task_id: &'a str,
     pub task_type: ProofType,
     pub status: ProofStatus,
-    pub proof: Cow<'a, str>,
+    pub proof: &'a str,
     pub failure_type: Option<ProofFailureType>,
-    pub failure_msg: Option<Cow<'a, str>>,
+    pub failure_msg: Option<&'a str>,
     pub universal: bool,
 }
 
@@ -292,13 +285,15 @@ mod tests {
         let private_key_hex = "8b8df68fddf7ee2724b79ccbd07799909d59b4dd4f4df3f6ecdc4fb8d56bdf4c";
         let key_signer = KeySigner::new_from_secret_key(private_key_hex).unwrap();
 
+        let prover_types = vec![ProverType::Chunk];
+        let vks = vec!["mock_vk".to_string()];
         let login_message = LoginMessage {
             challenge: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjQ4Mzg0ODUsIm9yaWdfaWF0IjoxNzI0ODM0ODg1LCJyYW5kb20iOiJ6QmdNZGstNGc4UzNUNTFrVEFsYk1RTXg2TGJ4SUs4czY3ejM2SlNuSFlJPSJ9.x9PvihhNx2w4_OX5uCrv8QJCNYVQkIi-K2k8XFXYmik".into(),
             prover_version: "v4.4.45-37af5ef5-38a68e2-1c5093c".into(),
             prover_name: "test".into(),
             prover_provider_type: ProverProviderType::Internal,
-            prover_types: (&[ProverType::Chunk]).into(),
-            vks: vec!["mock_vk".into()],
+            prover_types: &prover_types,
+            vks: &vks,
         };
 
         let buffer = alloy_rlp::encode(&login_message);

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -170,7 +170,7 @@ impl Encodable for ProverTypes<'_> {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, RlpEncodable)]
+#[derive(Debug, Clone, Serialize, RlpEncodable)]
 pub struct LoginMessage<'a> {
     pub challenge: Cow<'a, str>,
     pub prover_version: Cow<'a, str>,
@@ -180,7 +180,7 @@ pub struct LoginMessage<'a> {
     pub vks: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LoginRequest<'a> {
     pub message: LoginMessage<'a>,
     pub public_key: Cow<'a, str>,
@@ -188,14 +188,14 @@ pub struct LoginRequest<'a> {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct LoginResponseData {
+pub struct LoginResponse {
     pub time: String,
     pub token: String,
 }
 
-pub type ChallengeResponseData = LoginResponseData;
+pub type ChallengeResponse = LoginResponse;
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize)]
 pub struct GetTaskRequest<'a> {
     pub task_types: Vec<ProofType>,
     pub prover_height: Option<u64>,
@@ -203,8 +203,8 @@ pub struct GetTaskRequest<'a> {
     pub task_id: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
-pub struct GetTaskResponseData {
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct GetTaskResponse {
     pub uuid: String,
     pub task_id: String,
     pub task_type: ProofType,
@@ -212,7 +212,7 @@ pub struct GetTaskResponseData {
     pub hard_fork_name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)] // TODO: Default?
+#[derive(Debug, Clone, Serialize)] // TODO: Default?
 pub struct SubmitProofRequest<'a> {
     pub uuid: Cow<'a, str>,
     pub task_id: Cow<'a, str>,
@@ -223,9 +223,6 @@ pub struct SubmitProofRequest<'a> {
     pub failure_msg: Option<Cow<'a, str>>,
     pub universal: bool,
 }
-
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct SubmitProofResponseData {}
 
 #[derive(
     Default,

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -1,100 +1,190 @@
 use super::error::ErrorCode;
 use crate::prover::{ProofType, ProverProviderType};
-use rlp::{Encodable, RlpStream};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use alloy_rlp::{
+    BufMut, Decodable, EMPTY_STRING_CODE, Encodable, Header, RlpEncodable, length_of_length,
+};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_repr::{Deserialize_repr as DeserializeRepr, Serialize_repr as SerializeRepr};
+use std::borrow::Cow;
+use std::fmt;
+use strum::{EnumIs, FromRepr};
+
+#[derive(Debug, Clone)]
+pub enum Response<T> {
+    Ok(T),
+    Err(RpcError),
+}
+
+impl<T> Response<T> {
+    pub const fn is_ok(&self) -> bool {
+        matches!(self, Response::Ok(_))
+    }
+
+    pub const fn is_error(&self) -> bool {
+        matches!(self, Response::Err(_))
+    }
+
+    pub const fn is_jwt_token_expired(&self) -> bool {
+        match self {
+            Response::Err(err) => err.code.is_jwt_token_expired(),
+            _ => false,
+        }
+    }
+
+    pub const fn is_empty_task_error(&self) -> bool {
+        match self {
+            Response::Err(err) => err.code.is_coordinator_empty_proof_data(),
+            _ => false,
+        }
+    }
+
+    pub fn into_result(self) -> Result<T, RpcError> {
+        match self {
+            Response::Ok(data) => Ok(data),
+            Response::Err(err) => Err(err),
+        }
+    }
+}
 
 #[derive(Deserialize)]
-pub struct Response<T> {
-    pub errcode: ErrorCode,
-    pub errmsg: String,
-    pub data: Option<T>,
+struct ResponseHelper<T> {
+    errcode: ErrorCode,
+    errmsg: String,
+    data: Option<T>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ProverType {
-    Undefined,
-    Chunk,
-    Batch,
-    OpenVM,
-}
-
-impl ProverType {
-    pub fn from_u8(v: u8) -> Self {
-        match v {
-            1 => ProverType::Chunk,
-            2 => ProverType::Batch,
-            3 => ProverType::OpenVM,
-            _ => ProverType::Undefined,
-        }
-    }
-
-    pub fn to_u8(&self) -> u8 {
-        match self {
-            ProverType::Undefined => 0,
-            ProverType::Chunk => 1,
-            ProverType::Batch => 2,
-            ProverType::OpenVM => 3,
-        }
-    }
-}
-
-impl Serialize for ProverType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u8(self.to_u8())
-    }
-}
-
-impl<'de> Deserialize<'de> for ProverType {
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Response<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let v: u8 = u8::deserialize(deserializer)?;
-        Ok(ProverType::from_u8(v))
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct LoginMessage {
-    pub challenge: String,
-    pub prover_version: String,
-    pub prover_name: String,
-    pub prover_provider_type: ProverProviderType,
-    pub prover_types: Vec<ProverType>,
-    pub vks: Vec<String>,
-}
-
-impl Encodable for LoginMessage {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        let num_fields = 6;
-        s.begin_list(num_fields);
-        s.append(&self.challenge);
-        s.append(&self.prover_version);
-        s.append(&self.prover_name);
-        s.append(&(self.prover_provider_type as u8));
-        // The ProverType in go side is an type alias of uint8
-        // A uint8 slice is treated as a string when doing the rlp encoding
-        let prover_types = self
-            .prover_types
-            .iter()
-            .map(|prover_type| prover_type.to_u8())
-            .collect::<Vec<u8>>();
-        s.append(&prover_types);
-        s.begin_list(self.vks.len());
-        for vk in &self.vks {
-            s.append(vk);
+        let helper = ResponseHelper::<T>::deserialize(deserializer)?;
+        if helper.errcode == ErrorCode::Success {
+            if let Some(data) = helper.data {
+                Ok(Response::Ok(data))
+            } else {
+                Err(serde::de::Error::custom(
+                    "Expected data field for successful response",
+                ))
+            }
+        } else {
+            Ok(Response::Err(RpcError {
+                code: helper.errcode,
+                msg: helper.errmsg,
+            }))
         }
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct LoginRequest {
-    pub message: LoginMessage,
-    pub public_key: String,
-    pub signature: String,
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcError {
+    code: ErrorCode,
+    msg: String,
+}
+
+impl RpcError {
+    pub fn code(&self) -> &ErrorCode {
+        &self.code
+    }
+
+    pub fn msg(&self) -> &str {
+        &self.msg
+    }
+}
+
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: {}", self.code, self.msg)
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializeRepr,
+    DeserializeRepr,
+    EnumIs,
+    strum::Display,
+    FromRepr,
+)]
+#[repr(u8)]
+pub enum ProverType {
+    Undefined = 0,
+    Chunk = 1,
+    Batch = 2,
+    OpenVM = 3,
+}
+
+impl Encodable for ProverType {
+    fn encode(&self, s: &mut dyn BufMut) {
+        (*self as u8).encode(s);
+    }
+}
+
+impl Decodable for ProverType {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let v = u8::decode(buf)?;
+        ProverType::from_repr(v).ok_or(alloy_rlp::Error::Custom("Invalid ProverType value"))
+    }
+}
+
+/// The ProverType in go side is a type alias of uint8
+/// A uint8 slice is treated as a string when doing the rlp encoding
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProverTypes<'a>(Cow<'a, [ProverType]>);
+
+impl<'a, T: Into<Cow<'a, [ProverType]>>> From<T> for ProverTypes<'a> {
+    fn from(value: T) -> Self {
+        ProverTypes(value.into())
+    }
+}
+
+/// See implementation of [`Encodable`] for [u8]
+impl Encodable for ProverTypes<'_> {
+    #[inline]
+    fn encode(&self, out: &mut dyn BufMut) {
+        if self.0.len() != 1 || self.0[0] as u8 >= EMPTY_STRING_CODE {
+            Header {
+                list: false,
+                payload_length: self.0.len(),
+            }
+            .encode(out);
+        }
+        for prover_type in self.0.iter() {
+            out.put_u8(*prover_type as u8);
+        }
+    }
+    #[inline]
+    fn length(&self) -> usize {
+        let mut len = self.0.len();
+        if len != 1 || self.0[0] as u8 >= EMPTY_STRING_CODE {
+            len += length_of_length(len);
+        }
+        len
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, RlpEncodable)]
+pub struct LoginMessage<'a> {
+    pub challenge: Cow<'a, str>,
+    pub prover_version: Cow<'a, str>,
+    pub prover_name: Cow<'a, str>,
+    pub prover_provider_type: ProverProviderType,
+    pub prover_types: ProverTypes<'a>,
+    pub vks: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginRequest<'a> {
+    pub message: LoginMessage<'a>,
+    pub public_key: Cow<'a, str>,
+    pub signature: Cow<'a, str>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -105,12 +195,12 @@ pub struct LoginResponseData {
 
 pub type ChallengeResponseData = LoginResponseData;
 
-#[derive(Default, Serialize, Deserialize)]
-pub struct GetTaskRequest {
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+pub struct GetTaskRequest<'a> {
     pub task_types: Vec<ProofType>,
     pub prover_height: Option<u64>,
     pub universal: bool,
-    pub task_id: Option<String>,
+    pub task_id: Option<Cow<'a, str>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -122,102 +212,60 @@ pub struct GetTaskResponseData {
     pub hard_fork_name: String,
 }
 
-#[derive(Serialize, Deserialize)] // TODO: Default?
-pub struct SubmitProofRequest {
-    pub uuid: String,
-    pub task_id: String,
+#[derive(Debug, Clone, Serialize, Deserialize)] // TODO: Default?
+pub struct SubmitProofRequest<'a> {
+    pub uuid: Cow<'a, str>,
+    pub task_id: Cow<'a, str>,
     pub task_type: ProofType,
     pub status: ProofStatus,
-    pub proof: String,
+    pub proof: Cow<'a, str>,
     pub failure_type: Option<ProofFailureType>,
-    pub failure_msg: Option<String>,
+    pub failure_msg: Option<Cow<'a, str>>,
     pub universal: bool,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitProofResponseData {}
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializeRepr,
+    DeserializeRepr,
+    EnumIs,
+    strum::Display,
+    FromRepr,
+)]
+#[repr(u8)]
 pub enum ProofFailureType {
-    Undefined,
-    Panic,
-    NoPanic,
+    #[default]
+    Undefined = 0,
+    Panic = 1,
+    NoPanic = 2,
 }
 
-impl ProofFailureType {
-    fn from_u8(v: u8) -> Self {
-        match v {
-            1 => ProofFailureType::Panic,
-            2 => ProofFailureType::NoPanic,
-            _ => ProofFailureType::Undefined,
-        }
-    }
-}
-
-impl Serialize for ProofFailureType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *self {
-            ProofFailureType::Undefined => serializer.serialize_u8(0),
-            ProofFailureType::Panic => serializer.serialize_u8(1),
-            ProofFailureType::NoPanic => serializer.serialize_u8(2),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for ProofFailureType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let v: u8 = u8::deserialize(deserializer)?;
-        Ok(ProofFailureType::from_u8(v))
-    }
-}
-
-impl Default for ProofFailureType {
-    fn default() -> Self {
-        Self::Undefined
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializeRepr,
+    DeserializeRepr,
+    EnumIs,
+    strum::Display,
+    FromRepr,
+)]
+#[repr(u8)]
 pub enum ProofStatus {
-    Ok,
-    Error,
-}
-
-impl ProofStatus {
-    fn from_u8(v: u8) -> Self {
-        match v {
-            0 => ProofStatus::Ok,
-            _ => ProofStatus::Error,
-        }
-    }
-}
-
-impl Serialize for ProofStatus {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *self {
-            ProofStatus::Ok => serializer.serialize_u8(0),
-            ProofStatus::Error => serializer.serialize_u8(1),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for ProofStatus {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let v: u8 = u8::deserialize(deserializer)?;
-        Ok(ProofStatus::from_u8(v))
-    }
+    Ok = 0,
+    Error = 1,
 }
 
 #[cfg(test)]
@@ -241,15 +289,15 @@ mod tests {
         let key_signer = KeySigner::new_from_secret_key(private_key_hex).unwrap();
 
         let login_message = LoginMessage {
-            challenge: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjQ4Mzg0ODUsIm9yaWdfaWF0IjoxNzI0ODM0ODg1LCJyYW5kb20iOiJ6QmdNZGstNGc4UzNUNTFrVEFsYk1RTXg2TGJ4SUs4czY3ejM2SlNuSFlJPSJ9.x9PvihhNx2w4_OX5uCrv8QJCNYVQkIi-K2k8XFXYmik".to_string(),
-            prover_version: "v4.4.45-37af5ef5-38a68e2-1c5093c".to_string(),
-            prover_name: "test".to_string(),
+            challenge: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3MjQ4Mzg0ODUsIm9yaWdfaWF0IjoxNzI0ODM0ODg1LCJyYW5kb20iOiJ6QmdNZGstNGc4UzNUNTFrVEFsYk1RTXg2TGJ4SUs4czY3ejM2SlNuSFlJPSJ9.x9PvihhNx2w4_OX5uCrv8QJCNYVQkIi-K2k8XFXYmik".into(),
+            prover_version: "v4.4.45-37af5ef5-38a68e2-1c5093c".into(),
+            prover_name: "test".into(),
             prover_provider_type: ProverProviderType::Internal,
-            prover_types: vec![ProverType::Chunk],
-            vks: vec!["mock_vk".to_string()],
+            prover_types: (&[ProverType::Chunk]).into(),
+            vks: vec!["mock_vk".into()],
         };
 
-        let buffer = rlp::encode(&login_message);
+        let buffer = alloy_rlp::encode(&login_message);
         let signature = key_signer
             .sign_buffer(&buffer)
             .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))

--- a/src/coordinator_handler/types.rs
+++ b/src/coordinator_handler/types.rs
@@ -252,7 +252,7 @@ mod tests {
         let buffer = rlp::encode(&login_message);
         let signature = key_signer
             .sign_buffer(&buffer)
-            .map_err(|e| anyhow::anyhow!("Failed to sign the login message: {e}"))
+            .map_err(|e| eyre::eyre!("Failed to sign the login message: {e}"))
             .unwrap();
 
         // expected signature from coordinator's TestGenerateSignature

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,7 +7,7 @@ pub struct Db {
 }
 
 impl Db {
-    pub fn new(path: &str) -> anyhow::Result<Self> {
+    pub fn new(path: &str) -> eyre::Result<Self> {
         let db = DB::open_default(path)?;
         Ok(Self { db })
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use crate::coordinator_handler::GetTaskResponseData;
+use crate::coordinator_handler::GetTaskResponse;
 use rocksdb::DB;
 use tracing::Level;
 
@@ -13,7 +13,7 @@ impl Db {
     }
 
     #[instrument(skip(self), level = Level::DEBUG)]
-    pub fn get_task(&self, public_key: String) -> (Option<GetTaskResponseData>, Option<String>) {
+    pub fn get_task(&self, public_key: String) -> (Option<GetTaskResponse>, Option<String>) {
         (
             self.get_coordinator_task_by_public_key(public_key.clone()),
             self.get_proving_task_id_by_public_key(public_key),
@@ -24,7 +24,7 @@ impl Db {
     pub fn set_task(
         &self,
         public_key: String,
-        coordinator_task: &GetTaskResponseData,
+        coordinator_task: &GetTaskResponse,
         proving_task_id: String,
     ) {
         self.set_coordinator_task_by_public_key(public_key.clone(), coordinator_task);
@@ -36,10 +36,7 @@ impl Db {
         self.delete_proving_task_id_by_public_key(public_key);
     }
 
-    fn get_coordinator_task_by_public_key(
-        &self,
-        public_key: String,
-    ) -> Option<GetTaskResponseData> {
+    fn get_coordinator_task_by_public_key(&self, public_key: String) -> Option<GetTaskResponse> {
         self.db
             .get(fmt_coordinator_task_key(public_key))
             .ok()?
@@ -57,7 +54,7 @@ impl Db {
     fn set_coordinator_task_by_public_key(
         &self,
         public_key: String,
-        coordinator_task: &GetTaskResponseData,
+        coordinator_task: &GetTaskResponse,
     ) {
         let _ = serde_json::to_vec(coordinator_task)
             .map(|bytes| self.db.put(fmt_coordinator_task_key(public_key), bytes));

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use crate::coordinator_handler::GetTaskResponseData;
 use rocksdb::DB;
+use tracing::Level;
 
 pub struct Db {
     db: DB,
@@ -11,21 +12,21 @@ impl Db {
         Ok(Self { db })
     }
 
+    #[instrument(skip(self), level = Level::DEBUG)]
     pub fn get_task(&self, public_key: String) -> (Option<GetTaskResponseData>, Option<String>) {
-        log::debug!("[db], get task, public_key: {public_key}");
         (
             self.get_coordinator_task_by_public_key(public_key.clone()),
             self.get_proving_task_id_by_public_key(public_key),
         )
     }
 
+    #[instrument(skip_all, fields(public_key = %public_key), level = Level::DEBUG)]
     pub fn set_task(
         &self,
         public_key: String,
         coordinator_task: &GetTaskResponseData,
         proving_task_id: String,
     ) {
-        log::debug!("[db], set task, public_key: {public_key}");
         self.set_coordinator_task_by_public_key(public_key.clone(), coordinator_task);
         self.set_proving_task_id_by_public_key(public_key, proving_task_id);
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,6 @@
 use crate::coordinator_handler::GetTaskResponse;
-use rocksdb::DB;
+use rocksdb::{DB, WriteBatch};
+use std::path::Path;
 use tracing::Level;
 
 pub struct Db {
@@ -7,79 +8,111 @@ pub struct Db {
 }
 
 impl Db {
-    pub fn new(path: &str) -> eyre::Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> eyre::Result<Self> {
         let db = DB::open_default(path)?;
         Ok(Self { db })
     }
 
     #[instrument(skip(self), level = Level::DEBUG)]
-    pub fn get_task(&self, public_key: String) -> (Option<GetTaskResponse>, Option<String>) {
-        (
-            self.get_coordinator_task_by_public_key(public_key.clone()),
-            self.get_proving_task_id_by_public_key(public_key),
-        )
+    pub fn get_task(&self, public_key: &str) -> Option<(GetTaskResponse, String)> {
+        self.get_task_inner(public_key)
+            .inspect_err(|e| {
+                tracing::error!("Failed to get task for public_key {public_key}: {e:?}");
+            })
+            .unwrap_or_default()
+    }
+
+    fn get_task_inner(&self, public_key: &str) -> eyre::Result<Option<(GetTaskResponse, String)>> {
+        let coordinator_task_key = fmt_coordinator_task_key(public_key);
+        let proving_task_id_key = fmt_proving_task_id_key(public_key);
+
+        let mut results = self
+            .db
+            .multi_get([coordinator_task_key, proving_task_id_key])
+            .into_iter();
+
+        let Some(coordinator_task_bytes) = results.next().unwrap()? else {
+            return Ok(None);
+        };
+        let Some(proving_task_id_bytes) = results.next().unwrap()? else {
+            return Ok(None);
+        };
+
+        let coordinator_task: GetTaskResponse = serde_json::from_slice(&coordinator_task_bytes)?;
+        let proving_task_id = String::from_utf8(proving_task_id_bytes)?;
+
+        Ok(Some((coordinator_task, proving_task_id)))
     }
 
     #[instrument(skip_all, fields(public_key = %public_key), level = Level::DEBUG)]
     pub fn set_task(
         &self,
-        public_key: String,
+        public_key: &str,
         coordinator_task: &GetTaskResponse,
-        proving_task_id: String,
+        proving_task_id: &str,
     ) {
-        self.set_coordinator_task_by_public_key(public_key.clone(), coordinator_task);
-        self.set_proving_task_id_by_public_key(public_key, proving_task_id);
+        if let Err(e) = self.set_task_inner(public_key, coordinator_task, proving_task_id) {
+            tracing::error!("Failed to set task for public_key {public_key}: {e:?}");
+        }
     }
 
-    pub fn delete_task(&self, public_key: String) {
-        self.delete_coordinator_task_by_public_key(public_key.clone());
-        self.delete_proving_task_id_by_public_key(public_key);
-    }
-
-    fn get_coordinator_task_by_public_key(&self, public_key: String) -> Option<GetTaskResponse> {
-        self.db
-            .get(fmt_coordinator_task_key(public_key))
-            .ok()?
-            .as_ref()
-            .and_then(|v| serde_json::from_slice(v).ok())
-    }
-
-    fn get_proving_task_id_by_public_key(&self, public_key: String) -> Option<String> {
-        self.db
-            .get(fmt_proving_task_id_key(public_key))
-            .ok()?
-            .and_then(|v| String::from_utf8(v).ok())
-    }
-
-    fn set_coordinator_task_by_public_key(
+    fn set_task_inner(
         &self,
-        public_key: String,
+        public_key: &str,
         coordinator_task: &GetTaskResponse,
-    ) {
-        let _ = serde_json::to_vec(coordinator_task)
-            .map(|bytes| self.db.put(fmt_coordinator_task_key(public_key), bytes));
-    }
+        proving_task_id: &str,
+    ) -> eyre::Result<()> {
+        let task = serde_json::to_vec(coordinator_task)?;
 
-    fn set_proving_task_id_by_public_key(&self, public_key: String, proving_task_id: String) {
-        let _ = self.db.put(
+        let mut write_batch = WriteBatch::default();
+        // set_coordinator_task_by_public_key
+        write_batch.put(fmt_coordinator_task_key(public_key), task);
+        // set_proving_task_id_by_public_key
+        write_batch.put(
             fmt_proving_task_id_key(public_key),
             proving_task_id.as_bytes(),
         );
+        self.db.write(write_batch)?;
+
+        Ok(())
     }
 
-    fn delete_coordinator_task_by_public_key(&self, public_key: String) {
-        let _ = self.db.delete(fmt_coordinator_task_key(public_key));
+    pub fn delete_task(&self, public_key: &str) {
+        if let Err(e) = self.delete_task_inner(public_key) {
+            tracing::error!("Failed to delete task for public_key {public_key}: {e:?}");
+        }
     }
 
-    fn delete_proving_task_id_by_public_key(&self, public_key: String) {
-        let _ = self.db.delete(fmt_proving_task_id_key(public_key));
+    fn delete_task_inner(&self, public_key: &str) -> eyre::Result<()> {
+        let mut write_batch = WriteBatch::default();
+
+        // delete_coordinator_task_by_public_key
+        write_batch.delete(fmt_coordinator_task_key(public_key));
+        // delete_proving_task_id_by_public_key
+        write_batch.delete(fmt_proving_task_id_key(public_key));
+
+        self.db.write(write_batch)?;
+        Ok(())
+    }
+
+    /// Expose the inner RocksDB instance for advanced operations.
+    pub fn inner(&self) -> &DB {
+        &self.db
     }
 }
 
-fn fmt_coordinator_task_key(public_key: String) -> String {
-    format!("last_coordinator_task_{}", public_key)
+/// Format keys for storing and retrieving tasks in the database.
+pub static COORDINATOR_TASK_KEY_PREFIX: &str = "last_coordinator_task_";
+
+/// Format keys for storing and retrieving proving task IDs in the database.
+pub static PROVING_TASK_ID_KEY_PREFIX: &str = "last_proving_task_id_";
+
+#[inline]
+pub fn fmt_coordinator_task_key(public_key: &str) -> String {
+    format!("{COORDINATOR_TASK_KEY_PREFIX}{public_key}")
 }
 
-fn fmt_proving_task_id_key(public_key: String) -> String {
-    format!("last_proving_task_id_{}", public_key)
+#[inline]
+pub fn fmt_proving_task_id_key(public_key: &str) -> String {
+    format!("{PROVING_TASK_ID_KEY_PREFIX}{public_key}")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate tracing;
+
 pub mod config;
 pub mod coordinator_handler;
 pub mod db;

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -97,6 +97,9 @@ where
                 .as_ref()
                 .map(|path| Db::new(path.as_str()))
                 .transpose()?,
+            poll_interval_sec: self.cfg.prover.poll_interval_sec,
+            randomized_delay_sec: self.cfg.prover.randomized_delay_sec,
+            suppress_empty_task_error: self.cfg.prover.suppress_empty_task_error,
         })
     }
 }

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -100,7 +100,6 @@ where
                 .transpose()?,
             poll_interval_sec: self.cfg.prover.poll_interval_sec,
             randomized_delay_sec: self.cfg.prover.randomized_delay_sec,
-            suppress_empty_task_error: self.cfg.prover.suppress_empty_task_error,
         })
     }
 }

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -6,8 +6,8 @@ use crate::{
     coordinator_handler::{CoordinatorClient, KeySigner},
     db::Db,
     prover::{
-        proving_service::{GetVkRequest, ProvingService},
         Prover,
+        proving_service::{GetVkRequest, ProvingService},
     },
     utils::format_cloud_prover_name,
 };
@@ -75,6 +75,7 @@ where
                 CoordinatorClient::new(
                     self.cfg.coordinator.clone(),
                     self.cfg.coordinator_prover_type(),
+                    self.cfg.coordinator.suppress_empty_task_error,
                     get_vk_response.vks.clone(),
                     prover_name,
                     prover_provider_type,
@@ -99,7 +100,6 @@ where
                 .transpose()?,
             poll_interval_sec: self.cfg.prover.poll_interval_sec,
             randomized_delay_sec: self.cfg.prover.randomized_delay_sec,
-            suppress_empty_task_error: self.cfg.prover.suppress_empty_task_error,
         })
     }
 }

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -97,6 +97,8 @@ where
                 .as_ref()
                 .map(|path| Db::new(path.as_str()))
                 .transpose()?,
+            poll_interval_sec: self.cfg.prover.poll_interval_sec,
+            suppress_empty_task_error: self.cfg.prover.suppress_empty_task_error,
         })
     }
 }

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -43,11 +43,8 @@ where
             eyre::bail!("failed to get vk: {}", error);
         }
 
-        let prover_provider_type = if self.proving_service.is_local() {
-            ProverProviderType::Internal
-        } else {
-            ProverProviderType::External
-        };
+        // FIXME: should derive from `self.proving_service.is_local()`, but coordinator has a bug when handling external provers
+        let prover_provider_type = ProverProviderType::Internal;
 
         let key_signers: Result<Vec<_>, _> = (0..self.cfg.prover.n_workers)
             .map(|i| {

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -98,6 +98,7 @@ where
                 .map(|path| Db::new(path.as_str()))
                 .transpose()?,
             poll_interval_sec: self.cfg.prover.poll_interval_sec,
+            randomized_delay_sec: self.cfg.prover.randomized_delay_sec,
             suppress_empty_task_error: self.cfg.prover.suppress_empty_task_error,
         })
     }

--- a/src/prover/builder.rs
+++ b/src/prover/builder.rs
@@ -29,9 +29,9 @@ where
         }
     }
 
-    pub async fn build(self) -> anyhow::Result<Prover<Backend>> {
+    pub async fn build(self) -> eyre::Result<Prover<Backend>> {
         if self.proving_service.is_local() && self.cfg.prover.n_workers > 1 {
-            anyhow::bail!("cannot use multiple workers with local proving service");
+            eyre::bail!("cannot use multiple workers with local proving service");
         }
 
         let get_vk_request = GetVkRequest {
@@ -40,7 +40,7 @@ where
         };
         let get_vk_response = self.proving_service.get_vks(get_vk_request).await;
         if let Some(error) = get_vk_response.error {
-            anyhow::bail!("failed to get vk: {}", error);
+            eyre::bail!("failed to get vk: {}", error);
         }
 
         let prover_provider_type = if self.proving_service.is_local() {
@@ -54,7 +54,7 @@ where
                 let keys_dir = PathBuf::from(&self.cfg.keys_dir);
                 if !keys_dir.exists() {
                     std::fs::create_dir_all(&keys_dir).map_err(|e| {
-                        anyhow::anyhow!(
+                        eyre::eyre!(
                             "failed to create keys directory {}: {e}",
                             keys_dir.display()
                         )
@@ -65,7 +65,7 @@ where
             })
             .collect();
         let key_signers =
-            key_signers.map_err(|e| anyhow::anyhow!("cannot create key_signer, err: {e}"))?;
+            key_signers.map_err(|e| eyre::eyre!("cannot create key_signer, err: {e}"))?;
 
         let coordinator_clients: Result<Vec<_>, _> = (0..self.cfg.prover.n_workers)
             .map(|i| {

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -291,7 +291,7 @@ where
                 })
                 .await;
 
-            let current_status = task.status; // capture for comparison
+            let current_status = task.status;
 
             match current_status {
                 TaskStatus::Queued | TaskStatus::Proving => {

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -4,19 +4,21 @@ pub mod types;
 
 use crate::{
     coordinator_handler::{
-        CoordinatorClient, ErrorCode, GetTaskRequest, GetTaskResponseData, ProofFailureType,
-        ProofStatus, SubmitProofRequest,
+        CoordinatorClient, GetTaskRequest, GetTaskResponseData, ProofFailureType, ProofStatus,
+        SubmitProofRequest,
     },
     db::Db,
 };
-use axum::{routing::get, Router};
+use axum::{Router, routing::get};
+use eyre::Context;
 use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
+use rand::Rng;
+use std::borrow::Cow;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use rand::Rng;
 use tokio::net::TcpListener;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tokio::{sync::RwLock, task::JoinSet};
 use tracing::Level;
 use tracing::{error, info, instrument};
@@ -33,7 +35,6 @@ pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     db: Option<Db>,
     poll_interval_sec: u64,
     randomized_delay_sec: u64,
-    suppress_empty_task_error: bool,
 }
 
 impl<Backend> Prover<Backend>
@@ -127,7 +128,7 @@ where
 
     async fn test_coordinator_connection(&self) {
         self.coordinator_clients[0]
-            .get_token(true)
+            .refresh_token()
             .await
             .expect("Failed to login to coordinator");
     }
@@ -170,14 +171,20 @@ where
                 .await;
         }
 
-        let mut get_task_request = self.build_get_task_request(None)?;
+        let mut get_task_request = GetTaskRequest {
+            task_types: self.proof_types.clone(),
+            prover_height: None,
+            universal: true,
+            task_id: None,
+        };
         if let Some((t, s)) = task_spec {
             get_task_request.task_types = vec![t];
-            get_task_request.task_id.replace(s.to_string());
+            get_task_request.task_id.replace(s.into());
         }
-        let Some(coordinator_task) = self
-            .get_coordinator_task(coordinator_client, &get_task_request)
-            .await?
+        let Some(coordinator_task) = coordinator_client
+            .get_task(&get_task_request)
+            .await
+            .context("failed to get task")?
         else {
             return Ok(());
         };
@@ -187,30 +194,6 @@ where
             .await?;
         self.handle_proving_progress(coordinator_client, &coordinator_task, proving_task.task_id)
             .await
-    }
-
-    async fn get_coordinator_task(
-        &self,
-        coordinator_client: &CoordinatorClient,
-        request: &GetTaskRequest,
-    ) -> eyre::Result<Option<GetTaskResponseData>> {
-        let coordinator_task = coordinator_client.get_task(request).await?;
-
-        if coordinator_task.errcode == ErrorCode::ErrCoordinatorEmptyProofData
-            && self.suppress_empty_task_error
-        {
-            return Ok(None);
-        }
-
-        if coordinator_task.errcode != ErrorCode::Success {
-            eyre::bail!(
-                "Failed to get task, errcode: {:?}, errmsg: {:?}",
-                coordinator_task.errcode,
-                coordinator_task.errmsg
-            );
-        }
-
-        Ok(coordinator_task.data)
     }
 
     async fn request_proving(
@@ -378,13 +361,13 @@ where
     ) -> eyre::Result<()> {
         let submit_proof_req = SubmitProofRequest {
             universal: true,
-            uuid: coordinator_task.uuid.clone(),
-            task_id: coordinator_task.task_id.clone(),
+            uuid: coordinator_task.uuid.as_str().into(),
+            task_id: coordinator_task.task_id.as_str().into(),
             task_type: coordinator_task.task_type,
             status,
-            proof: task.proof.unwrap_or_default(),
+            proof: task.proof.map(Into::into).unwrap_or(Cow::Borrowed("")),
             failure_type: failure_msg.as_ref().map(|_| ProofFailureType::Panic), // TODO: handle ProofFailureType::NoPanic
-            failure_msg,
+            failure_msg: failure_msg.map(Into::into),
         };
 
         let submit_proof_result = match coordinator_client.submit_proof(&submit_proof_req).await {
@@ -401,17 +384,18 @@ where
                 );
                 return Ok(());
             }
-        };
+        }
+        .into_result();
 
-        if submit_proof_result.errcode != ErrorCode::Success {
+        if let Err(e) = &submit_proof_result {
             info!(
                 prover_name = ?coordinator_client.prover_name,
                 ?coordinator_task.task_type,
                 ?coordinator_task.uuid,
                 ?coordinator_task.task_id,
                 ?task.task_id,
-                errcode = ?submit_proof_result.errcode,
-                errmsg = ?submit_proof_result.errmsg,
+                code = ?e.code(),
+                msg = ?e.msg(),
                 "Failed to submit proof due to coordinator error"
             );
         } else {
@@ -425,15 +409,6 @@ where
             );
         }
         Ok(())
-    }
-
-    fn build_get_task_request(&self, prover_height: Option<u64>) -> eyre::Result<GetTaskRequest> {
-        Ok(GetTaskRequest {
-            task_types: self.proof_types.clone(),
-            prover_height,
-            universal: true,
-            task_id: None,
-        })
     }
 
     fn get_proving_input(&self, task: &GetTaskResponseData) -> eyre::Result<ProveRequest> {
@@ -462,56 +437,5 @@ where
         let mut rng = rand::rng();
         let random_delay = rng.random_range(0..self.randomized_delay_sec * 1000);
         base_delay + Duration::from_millis(random_delay)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::config::Config;
-    use crate::prover::{
-        proving_service::{
-            GetVkRequest, GetVkResponse, ProveRequest, ProveResponse, QueryTaskRequest,
-            QueryTaskResponse,
-        },
-        ProverBuilder, ProvingService,
-    };
-    use async_trait::async_trait;
-    use tokio;
-
-    struct MockProver {}
-
-    #[async_trait]
-    impl ProvingService for MockProver {
-        fn is_local(&self) -> bool {
-            true
-        }
-        async fn get_vks(&self, _: GetVkRequest) -> GetVkResponse {
-            GetVkResponse {
-                ..Default::default()
-            }
-        }
-        async fn prove(&mut self, _: ProveRequest) -> ProveResponse {
-            ProveResponse {
-                ..Default::default()
-            }
-        }
-        async fn query_task(&mut self, _: QueryTaskRequest) -> QueryTaskResponse {
-            QueryTaskResponse {
-                ..Default::default()
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_build_get_task_request() {
-        let cfg = Config::from_file("conf/config.json".to_string()).unwrap();
-        let prover_service = MockProver {};
-        let prover = ProverBuilder::new(cfg, prover_service)
-            .build()
-            .await
-            .unwrap();
-
-        let get_task_request = prover.build_get_task_request(None);
-        assert!(get_task_request.is_ok())
     }
 }

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -1,6 +1,8 @@
 pub mod builder;
 pub mod proving_service;
 pub mod types;
+
+use std::future::IntoFuture;
 use crate::{
     coordinator_handler::{
         CoordinatorClient, ErrorCode, GetTaskRequest, GetTaskResponseData, ProofFailureType,
@@ -14,6 +16,7 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use tokio::time::{sleep, Duration};
 use tokio::{sync::RwLock, task::JoinSet};
+use tokio::net::TcpListener;
 use tracing::Level;
 use tracing::{error, info, instrument};
 
@@ -43,7 +46,10 @@ where
         let app = Router::new().route("/", get(|| async { "OK" }));
         let addr = SocketAddr::from_str(&self.health_listener_addr)
             .expect("Failed to parse socket address");
-        let server = axum::Server::bind(&addr).serve(app.into_make_service());
+        let listener = TcpListener::bind(addr)
+            .await
+            .expect("Failed to bind health check listener");
+        let server = axum::serve(listener, app).into_future();
         let health_check_server_task = tokio::spawn(server);
 
         let mut provers = JoinSet::new();
@@ -143,7 +149,7 @@ where
         &self,
         coordinator_client: &CoordinatorClient,
         task_spec: Option<(ProofType, &str)>,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         if let (Some(coordinator_task), Some(mut proving_task_id)) = self
             .db
             .as_ref()
@@ -182,11 +188,11 @@ where
         &self,
         coordinator_client: &CoordinatorClient,
         request: &GetTaskRequest,
-    ) -> anyhow::Result<GetTaskResponseData> {
+    ) -> eyre::Result<GetTaskResponseData> {
         let coordinator_task = coordinator_client.get_task(request).await?;
 
         if coordinator_task.errcode != ErrorCode::Success {
-            anyhow::bail!(
+            eyre::bail!(
                 "Failed to get task, errcode: {:?}, errmsg: {:?}",
                 coordinator_task.errcode,
                 coordinator_task.errmsg
@@ -195,14 +201,14 @@ where
 
         coordinator_task
             .data
-            .ok_or_else(|| anyhow::anyhow!("No task available"))
+            .ok_or_else(|| eyre::eyre!("No task available"))
     }
 
     async fn request_proving(
         &self,
         coordinator_client: &CoordinatorClient,
         coordinator_task: &GetTaskResponseData,
-    ) -> anyhow::Result<proving_service::ProveResponse> {
+    ) -> eyre::Result<proving_service::ProveResponse> {
         let proving_input = match self.get_proving_input(coordinator_task) {
             Ok(result) => result,
             Err(error) => {
@@ -214,7 +220,7 @@ where
                     Some(format!("failed to build proving input: error {:?}", error)),
                 )
                 .await?;
-                anyhow::bail!(
+                eyre::bail!(
                     "Failed to build proving input. task_type: {:?}, coordinator_task_uuid: {:?}, coordinator_task_id: {:?}, err: {:?}",
                     coordinator_task.task_type,
                     coordinator_task.uuid,
@@ -239,7 +245,7 @@ where
                 Some(format!("failed to request proving: error {:?}", error)),
             )
             .await?;
-            anyhow::bail!(
+            eyre::bail!(
                 "Failed to request proving_service to prove. task_type: {:?}, coordinator_task_uuid: {:?}, coordinator_task_id: {:?}, err: {:?}",
                 coordinator_task.task_type,
                 coordinator_task.uuid,
@@ -256,7 +262,7 @@ where
         coordinator_client: &CoordinatorClient,
         coordinator_task: &GetTaskResponseData,
         proving_service_task_id: String,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         let prover_name = &coordinator_client.prover_name;
         let public_key = &coordinator_client.key_signer.get_public_key();
         let task_type = coordinator_task.task_type;
@@ -352,7 +358,7 @@ where
         task: proving_service::QueryTaskResponse,
         status: ProofStatus,
         failure_msg: Option<String>,
-    ) -> anyhow::Result<()> {
+    ) -> eyre::Result<()> {
         let submit_proof_req = SubmitProofRequest {
             universal: true,
             uuid: coordinator_task.uuid.clone(),
@@ -404,7 +410,7 @@ where
         Ok(())
     }
 
-    fn build_get_task_request(&self, prover_height: Option<u64>) -> anyhow::Result<GetTaskRequest> {
+    fn build_get_task_request(&self, prover_height: Option<u64>) -> eyre::Result<GetTaskRequest> {
         Ok(GetTaskRequest {
             task_types: self.proof_types.clone(),
             prover_height,
@@ -413,8 +419,8 @@ where
         })
     }
 
-    fn get_proving_input(&self, task: &GetTaskResponseData) -> anyhow::Result<ProveRequest> {
-        anyhow::ensure!(
+    fn get_proving_input(&self, task: &GetTaskResponseData) -> eyre::Result<ProveRequest> {
+        eyre::ensure!(
             self.proof_types.contains(&task.task_type),
             "unsupported task type. self: {:?}, task: {:?}, coordinator_task_uuid: {:?}, coordinator_task_id: {:?}",
             self.proof_types,

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -278,6 +278,9 @@ where
         let coordinator_task_uuid = &coordinator_task.uuid;
         let coordinator_task_id = &coordinator_task.task_id;
 
+        // Track last observed status to avoid spamming logs when status hasn't changed.
+        let mut last_status: Option<TaskStatus> = None;
+
         loop {
             let task = self
                 .proving_service
@@ -288,17 +291,22 @@ where
                 })
                 .await;
 
-            match task.status {
+            let current_status = task.status; // capture for comparison
+
+            match current_status {
                 TaskStatus::Queued | TaskStatus::Proving => {
-                    info!(
-                        ?prover_name,
-                        ?task_type,
-                        ?coordinator_task_uuid,
-                        ?coordinator_task_id,
-                        ?proving_service_task_id,
-                        status = ?task.status,
-                        "Task status update"
-                    );
+                    if last_status != Some(current_status) {
+                        info!(
+                            ?prover_name,
+                            ?task_type,
+                            ?coordinator_task_uuid,
+                            ?coordinator_task_id,
+                            ?proving_service_task_id,
+                            status = ?current_status,
+                            "Task status update"
+                        );
+                    }
+                    last_status.replace(current_status);
                     if let Some(db) = &self.db {
                         db.set_task(
                             public_key.clone(),

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -126,7 +126,7 @@ where
             info!(?prover_name, "Getting task from coordinator");
 
             if let Err(e) = self.handle_task(coordinator_client, None).await {
-                error!(?prover_name, ?e, "Error handling task");
+                error!(prover_name, e, "Error handling task");
             }
 
             sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -158,12 +158,10 @@ where
         {
             let task_id = coordinator_task.clone().task_id;
             debug!(task_id = %task_id, "got previous task from db");
-            if self.proving_service.read().await.is_local() {
-                let proving_task = self
-                    .request_proving(coordinator_client, &coordinator_task)
-                    .await?;
-                proving_task_id = proving_task.task_id
-            }
+            let proving_task = self
+                .request_proving(coordinator_client, &coordinator_task)
+                .await?;
+            proving_task_id = proving_task.task_id;
             return self
                 .handle_proving_progress(coordinator_client, &coordinator_task, proving_task_id)
                 .await;

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -2,7 +2,6 @@ pub mod builder;
 pub mod proving_service;
 pub mod types;
 
-use std::future::IntoFuture;
 use crate::{
     coordinator_handler::{
         CoordinatorClient, ErrorCode, GetTaskRequest, GetTaskResponseData, ProofFailureType,
@@ -12,17 +11,17 @@ use crate::{
 };
 use axum::{routing::get, Router};
 use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
+use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use rand::Rng;
+use tokio::net::TcpListener;
 use tokio::time::{sleep, Duration};
 use tokio::{sync::RwLock, task::JoinSet};
-use tokio::net::TcpListener;
 use tracing::Level;
 use tracing::{error, info, instrument};
 
 pub use {builder::ProverBuilder, proving_service::ProvingService, types::*};
-
-const WORKER_SLEEP_SEC: u64 = 20;
 
 pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     proof_types: Vec<ProofType>,
@@ -32,6 +31,9 @@ pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     n_workers: usize,
     health_listener_addr: String,
     db: Option<Db>,
+    poll_interval_sec: u64,
+    randomized_delay_sec: u64,
+    suppress_empty_task_error: bool,
 }
 
 impl<Backend> Prover<Backend>
@@ -59,7 +61,6 @@ where
             provers.spawn(async move {
                 self_clone.working_loop(i).await;
             });
-            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         tokio::select! {
@@ -94,6 +95,9 @@ where
             let task_str = task.to_string();
             let i = work_set.pop().expect("can not be empty");
             provers.spawn(async move {
+                // Soft start delay to stagger the provers
+                sleep(self_clone.poll_delay()).await;
+
                 let coordinator_client = &self_clone.coordinator_clients[i];
                 let prover_name = &coordinator_client.prover_name;
 
@@ -108,7 +112,6 @@ where
                 }
                 i
             });
-            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         // wait until all tasks has been done
@@ -131,20 +134,18 @@ where
 
     #[instrument(skip(self), level = Level::DEBUG)]
     async fn working_loop(&self, i: usize) {
+        // Soft start delay to stagger the provers
+        sleep(self.poll_delay()).await;
         loop {
             let coordinator_client = &self.coordinator_clients[i];
-            let prover_name = &coordinator_client.prover_name;
-
-            info!(?prover_name, "Getting task from coordinator");
-
             if let Err(e) = self.handle_task(coordinator_client, None).await {
-                error!(prover_name, error = e.to_string(), "Error handling task");
+                error!(prover_name = %coordinator_client.prover_name, error = e.to_string(), "Error handling task");
             }
-
-            sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;
+            sleep(self.poll_delay()).await;
         }
     }
 
+    #[instrument(skip(self, coordinator_client), level = Level::DEBUG)]
     async fn handle_task(
         &self,
         coordinator_client: &CoordinatorClient,
@@ -174,9 +175,13 @@ where
             get_task_request.task_types = vec![t];
             get_task_request.task_id.replace(s.to_string());
         }
-        let coordinator_task = self
+        let Some(coordinator_task) = self
             .get_coordinator_task(coordinator_client, &get_task_request)
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
+        info!(prover_name = %coordinator_client.prover_name, "Got task from coordinator");
         let proving_task = self
             .request_proving(coordinator_client, &coordinator_task)
             .await?;
@@ -188,8 +193,14 @@ where
         &self,
         coordinator_client: &CoordinatorClient,
         request: &GetTaskRequest,
-    ) -> eyre::Result<GetTaskResponseData> {
+    ) -> eyre::Result<Option<GetTaskResponseData>> {
         let coordinator_task = coordinator_client.get_task(request).await?;
+
+        if coordinator_task.errcode == ErrorCode::ErrCoordinatorEmptyProofData
+            && self.suppress_empty_task_error
+        {
+            return Ok(None);
+        }
 
         if coordinator_task.errcode != ErrorCode::Success {
             eyre::bail!(
@@ -199,9 +210,7 @@ where
             );
         }
 
-        coordinator_task
-            .data
-            .ok_or_else(|| eyre::eyre!("No task available"))
+        Ok(coordinator_task.data)
     }
 
     async fn request_proving(
@@ -269,6 +278,9 @@ where
         let coordinator_task_uuid = &coordinator_task.uuid;
         let coordinator_task_id = &coordinator_task.task_id;
 
+        // Track last observed status to avoid spamming logs when status hasn't changed.
+        let mut last_status: Option<TaskStatus> = None;
+
         loop {
             let task = self
                 .proving_service
@@ -279,17 +291,22 @@ where
                 })
                 .await;
 
-            match task.status {
+            let current_status = task.status;
+
+            match current_status {
                 TaskStatus::Queued | TaskStatus::Proving => {
-                    info!(
-                        ?prover_name,
-                        ?task_type,
-                        ?coordinator_task_uuid,
-                        ?coordinator_task_id,
-                        ?proving_service_task_id,
-                        status = ?task.status,
-                        "Task status update"
-                    );
+                    if last_status != Some(current_status) {
+                        info!(
+                            ?prover_name,
+                            ?task_type,
+                            ?coordinator_task_uuid,
+                            ?coordinator_task_id,
+                            ?proving_service_task_id,
+                            status = ?current_status,
+                            "Task status update"
+                        );
+                    }
+                    last_status.replace(current_status);
                     if let Some(db) = &self.db {
                         db.set_task(
                             public_key.clone(),
@@ -297,7 +314,7 @@ where
                             proving_service_task_id.clone(),
                         );
                     }
-                    sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;
+                    sleep(self.poll_delay()).await;
                 }
                 TaskStatus::Success => {
                     info!(
@@ -435,6 +452,16 @@ where
             hard_fork_name: task.hard_fork_name.clone(),
             input: task.task_data.clone(),
         })
+    }
+
+    fn poll_delay(&self) -> Duration {
+        let base_delay = Duration::from_secs(self.poll_interval_sec);
+        if self.randomized_delay_sec == 0 {
+            return base_delay;
+        }
+        let mut rng = rand::rng();
+        let random_delay = rng.random_range(0..self.randomized_delay_sec * 1000);
+        base_delay + Duration::from_millis(random_delay)
     }
 }
 

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -10,14 +10,13 @@ use crate::{
     db::Db,
 };
 use axum::{Router, routing::get};
-use eyre::Context;
 use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
+use rand::Rng;
 use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::str::FromStr;
-use rand::Rng;
 use tokio::net::TcpListener;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tokio::{sync::RwLock, task::JoinSet};
 use tracing::Level;
 use tracing::{error, info, instrument};
@@ -34,7 +33,6 @@ pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     db: Option<Db>,
     poll_interval_sec: u64,
     randomized_delay_sec: u64,
-    suppress_empty_task_error: bool,
 }
 
 impl<Backend> Prover<Backend>
@@ -179,12 +177,9 @@ where
         };
         if let Some((t, s)) = task_spec {
             get_task_request.task_types = vec![t];
-            get_task_request.task_id.replace(s.into());
+            get_task_request.task_id.replace(s);
         }
-        let Some(coordinator_task) = self
-            .get_coordinator_task(coordinator_client, &get_task_request)
-            .await?
-        else {
+        let Some(coordinator_task) = coordinator_client.get_task(&get_task_request).await? else {
             return Ok(());
         };
         info!(prover_name = %coordinator_client.prover_name, "Got task from coordinator");
@@ -193,30 +188,6 @@ where
             .await?;
         self.handle_proving_progress(coordinator_client, &coordinator_task, proving_task.task_id)
             .await
-    }
-
-    async fn get_coordinator_task(
-        &self,
-        coordinator_client: &CoordinatorClient,
-        request: &GetTaskRequest,
-    ) -> eyre::Result<Option<GetTaskResponseData>> {
-        let coordinator_task = coordinator_client.get_task(request).await?;
-
-        if coordinator_task.errcode == ErrorCode::ErrCoordinatorEmptyProofData
-            && self.suppress_empty_task_error
-        {
-            return Ok(None);
-        }
-
-        if coordinator_task.errcode != ErrorCode::Success {
-            eyre::bail!(
-                "Failed to get task, errcode: {:?}, errmsg: {:?}",
-                coordinator_task.errcode,
-                coordinator_task.errmsg
-            );
-        }
-
-        Ok(coordinator_task.data)
     }
 
     async fn request_proving(
@@ -314,11 +285,7 @@ where
                     }
                     last_status.replace(current_status);
                     if let Some(db) = &self.db {
-                        db.set_task(
-                            public_key.clone(),
-                            coordinator_task,
-                            proving_service_task_id.clone(),
-                        );
+                        db.set_task(public_key, coordinator_task, &proving_service_task_id);
                     }
                     sleep(self.poll_delay()).await;
                 }
@@ -340,7 +307,7 @@ where
                     )
                     .await?;
                     if let Some(db) = &self.db {
-                        db.delete_task(&public_key);
+                        db.delete_task(public_key);
                     }
                     break;
                 }
@@ -364,7 +331,7 @@ where
                     )
                     .await?;
                     if let Some(db) = &self.db {
-                        db.delete_task(&public_key);
+                        db.delete_task(public_key);
                     }
                     break;
                 }
@@ -384,13 +351,13 @@ where
     ) -> eyre::Result<()> {
         let submit_proof_req = SubmitProofRequest {
             universal: true,
-            uuid: coordinator_task.uuid.as_str().into(),
-            task_id: coordinator_task.task_id.as_str().into(),
+            uuid: coordinator_task.uuid.as_str(),
+            task_id: coordinator_task.task_id.as_str(),
             task_type: coordinator_task.task_type,
             status,
-            proof: task.proof.map(Into::into).unwrap_or(Cow::Borrowed("")),
+            proof: task.proof.as_deref().unwrap_or(""),
             failure_type: failure_msg.as_ref().map(|_| ProofFailureType::Panic), // TODO: handle ProofFailureType::NoPanic
-            failure_msg: failure_msg.map(Into::into),
+            failure_msg: failure_msg.as_deref(),
         };
 
         match coordinator_client.submit_proof(&submit_proof_req).await {
@@ -437,17 +404,6 @@ where
             input: task.task_data.clone(),
         })
     }
-
-    fn poll_delay(&self) -> Duration {
-        let base_delay = Duration::from_secs(self.poll_interval_sec);
-        if self.randomized_delay_sec == 0 {
-            return base_delay;
-        }
-        let mut rng = rand::rng();
-        let random_delay = rng.random_range(0..self.randomized_delay_sec * 1000);
-        base_delay + Duration::from_millis(random_delay)
-    }
-}
 
     fn poll_delay(&self) -> Duration {
         let base_delay = Duration::from_secs(self.poll_interval_sec);

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -97,7 +97,7 @@ where
                     .handle_task(coordinator_client, Some((task_type, task_str.as_str())))
                     .await
                 {
-                    error!(?prover_name, ?e, "Error handling task");
+                    error!(prover_name, error = e.to_string(), "Error handling task");
                     panic!("task fail");
                 }
                 i
@@ -126,7 +126,7 @@ where
             info!(?prover_name, "Getting task from coordinator");
 
             if let Err(e) = self.handle_task(coordinator_client, None).await {
-                error!(prover_name, e, "Error handling task");
+                error!(prover_name, error = e.to_string(), "Error handling task");
             }
 
             sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -12,9 +12,9 @@ use axum::{routing::get, Router};
 use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
 use std::net::SocketAddr;
 use std::str::FromStr;
-use std::thread;
 use tokio::time::{sleep, Duration};
 use tokio::{sync::RwLock, task::JoinSet};
+use tracing::Level;
 use tracing::{error, info, instrument};
 
 pub use {builder::ProverBuilder, proving_service::ProvingService, types::*};
@@ -36,7 +36,7 @@ where
     Backend: ProvingService + Send + Sync + 'static,
 {
     pub async fn run(self) {
-        assert!(self.n_workers == self.coordinator_clients.len());
+        assert_eq!(self.n_workers, self.coordinator_clients.len());
 
         self.test_coordinator_connection().await;
 
@@ -53,7 +53,7 @@ where
             provers.spawn(async move {
                 self_clone.working_loop(i).await;
             });
-            thread::sleep(Duration::from_secs(3)); // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
+            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         tokio::select! {
@@ -67,7 +67,7 @@ where
         tasks: &[String],
         task_type: ProofType,
     ) -> bool {
-        assert!(self.n_workers == self.coordinator_clients.len());
+        assert_eq!(self.n_workers, self.coordinator_clients.len());
 
         self.test_coordinator_connection().await;
 
@@ -102,17 +102,16 @@ where
                 }
                 i
             });
-            thread::sleep(Duration::from_secs(3)); // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
+            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         // wait until all tasks has been done
         while let Some(r) = provers.join_next().await {
-            if r.is_err() {
+            let Ok(r) = r else {
                 // quit since one task has failed
                 return false;
-            } else {
-                log::info!("worker {} has completed", r.unwrap());
-            }
+            };
+            info!("worker {r} has completed");
         }
         true
     }
@@ -124,7 +123,7 @@ where
             .expect("Failed to login to coordinator");
     }
 
-    #[instrument(skip(self))]
+    #[instrument(skip(self), level = Level::DEBUG)]
     async fn working_loop(&self, i: usize) {
         loop {
             let coordinator_client = &self.coordinator_clients[i];
@@ -152,7 +151,7 @@ where
             .unwrap_or_default()
         {
             let task_id = coordinator_task.clone().task_id;
-            log::debug!("got previous task from db, task_id: {task_id}");
+            debug!(task_id = %task_id, "got previous task from db");
             if self.proving_service.read().await.is_local() {
                 let proving_task = self
                     .request_proving(coordinator_client, &coordinator_task)

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -14,6 +14,7 @@ use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
 use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use rand::Rng;
 use tokio::net::TcpListener;
 use tokio::time::{sleep, Duration};
 use tokio::{sync::RwLock, task::JoinSet};
@@ -31,6 +32,7 @@ pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     health_listener_addr: String,
     db: Option<Db>,
     poll_interval_sec: u64,
+    randomized_delay_sec: u64,
     suppress_empty_task_error: bool,
 }
 
@@ -59,7 +61,6 @@ where
             provers.spawn(async move {
                 self_clone.working_loop(i).await;
             });
-            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         tokio::select! {
@@ -94,6 +95,9 @@ where
             let task_str = task.to_string();
             let i = work_set.pop().expect("can not be empty");
             provers.spawn(async move {
+                // Soft start delay to stagger the provers
+                sleep(self_clone.poll_delay()).await;
+
                 let coordinator_client = &self_clone.coordinator_clients[i];
                 let prover_name = &coordinator_client.prover_name;
 
@@ -108,7 +112,6 @@ where
                 }
                 i
             });
-            tokio::time::sleep(Duration::from_secs(3)).await; // Sleep for 3 seconds to avoid overwhelming the l2geth/coordinator with requests.
         }
 
         // wait until all tasks has been done
@@ -131,13 +134,14 @@ where
 
     #[instrument(skip(self), level = Level::DEBUG)]
     async fn working_loop(&self, i: usize) {
+        // Soft start delay to stagger the provers
+        sleep(self.poll_delay()).await;
         loop {
             let coordinator_client = &self.coordinator_clients[i];
             if let Err(e) = self.handle_task(coordinator_client, None).await {
                 error!(prover_name = %coordinator_client.prover_name, error = e.to_string(), "Error handling task");
             }
-
-            sleep(Duration::from_secs(self.poll_interval_sec)).await;
+            sleep(self.poll_delay()).await;
         }
     }
 
@@ -302,7 +306,7 @@ where
                             proving_service_task_id.clone(),
                         );
                     }
-                    sleep(Duration::from_secs(self.poll_interval_sec)).await;
+                    sleep(self.poll_delay()).await;
                 }
                 TaskStatus::Success => {
                     info!(
@@ -440,6 +444,16 @@ where
             hard_fork_name: task.hard_fork_name.clone(),
             input: task.task_data.clone(),
         })
+    }
+
+    fn poll_delay(&self) -> Duration {
+        let base_delay = Duration::from_secs(self.poll_interval_sec);
+        if self.randomized_delay_sec == 0 {
+            return base_delay;
+        }
+        let mut rng = rand::rng();
+        let random_delay = rng.random_range(0..self.randomized_delay_sec * 1000);
+        base_delay + Duration::from_millis(random_delay)
     }
 }
 

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -2,7 +2,6 @@ pub mod builder;
 pub mod proving_service;
 pub mod types;
 
-use std::future::IntoFuture;
 use crate::{
     coordinator_handler::{
         CoordinatorClient, ErrorCode, GetTaskRequest, GetTaskResponseData, ProofFailureType,
@@ -12,17 +11,16 @@ use crate::{
 };
 use axum::{routing::get, Router};
 use proving_service::{ProveRequest, QueryTaskRequest, TaskStatus};
+use std::future::IntoFuture;
 use std::net::SocketAddr;
 use std::str::FromStr;
+use tokio::net::TcpListener;
 use tokio::time::{sleep, Duration};
 use tokio::{sync::RwLock, task::JoinSet};
-use tokio::net::TcpListener;
 use tracing::Level;
 use tracing::{error, info, instrument};
 
 pub use {builder::ProverBuilder, proving_service::ProvingService, types::*};
-
-const WORKER_SLEEP_SEC: u64 = 20;
 
 pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     proof_types: Vec<ProofType>,
@@ -32,6 +30,8 @@ pub struct Prover<Backend: ProvingService + Send + Sync + 'static> {
     n_workers: usize,
     health_listener_addr: String,
     db: Option<Db>,
+    poll_interval_sec: u64,
+    suppress_empty_task_error: bool,
 }
 
 impl<Backend> Prover<Backend>
@@ -133,18 +133,15 @@ where
     async fn working_loop(&self, i: usize) {
         loop {
             let coordinator_client = &self.coordinator_clients[i];
-            let prover_name = &coordinator_client.prover_name;
-
-            info!(?prover_name, "Getting task from coordinator");
-
             if let Err(e) = self.handle_task(coordinator_client, None).await {
-                error!(prover_name, error = e.to_string(), "Error handling task");
+                error!(prover_name = %coordinator_client.prover_name, error = e.to_string(), "Error handling task");
             }
 
-            sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;
+            sleep(Duration::from_secs(self.poll_interval_sec)).await;
         }
     }
 
+    #[instrument(skip(self, coordinator_client), level = Level::DEBUG)]
     async fn handle_task(
         &self,
         coordinator_client: &CoordinatorClient,
@@ -174,9 +171,13 @@ where
             get_task_request.task_types = vec![t];
             get_task_request.task_id.replace(s.to_string());
         }
-        let coordinator_task = self
+        let Some(coordinator_task) = self
             .get_coordinator_task(coordinator_client, &get_task_request)
-            .await?;
+            .await?
+        else {
+            return Ok(());
+        };
+        info!(prover_name = %coordinator_client.prover_name, "Got task from coordinator");
         let proving_task = self
             .request_proving(coordinator_client, &coordinator_task)
             .await?;
@@ -188,8 +189,14 @@ where
         &self,
         coordinator_client: &CoordinatorClient,
         request: &GetTaskRequest,
-    ) -> eyre::Result<GetTaskResponseData> {
+    ) -> eyre::Result<Option<GetTaskResponseData>> {
         let coordinator_task = coordinator_client.get_task(request).await?;
+
+        if coordinator_task.errcode == ErrorCode::ErrCoordinatorEmptyProofData
+            && self.suppress_empty_task_error
+        {
+            return Ok(None);
+        }
 
         if coordinator_task.errcode != ErrorCode::Success {
             eyre::bail!(
@@ -199,9 +206,7 @@ where
             );
         }
 
-        coordinator_task
-            .data
-            .ok_or_else(|| eyre::eyre!("No task available"))
+        Ok(coordinator_task.data)
     }
 
     async fn request_proving(
@@ -297,7 +302,7 @@ where
                             proving_service_task_id.clone(),
                         );
                     }
-                    sleep(Duration::from_secs(WORKER_SLEEP_SEC)).await;
+                    sleep(Duration::from_secs(self.poll_interval_sec)).await;
                 }
                 TaskStatus::Success => {
                     info!(

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -4,7 +4,7 @@ pub mod types;
 
 use crate::{
     coordinator_handler::{
-        CoordinatorClient, GetTaskRequest, GetTaskResponseData, ProofFailureType, ProofStatus,
+        CoordinatorClient, GetTaskRequest, GetTaskResponse, ProofFailureType, ProofStatus,
         SubmitProofRequest,
     },
     db::Db,
@@ -199,7 +199,7 @@ where
     async fn request_proving(
         &self,
         coordinator_client: &CoordinatorClient,
-        coordinator_task: &GetTaskResponseData,
+        coordinator_task: &GetTaskResponse,
     ) -> eyre::Result<proving_service::ProveResponse> {
         let proving_input = match self.get_proving_input(coordinator_task) {
             Ok(result) => result,
@@ -252,7 +252,7 @@ where
     async fn handle_proving_progress(
         &self,
         coordinator_client: &CoordinatorClient,
-        coordinator_task: &GetTaskResponseData,
+        coordinator_task: &GetTaskResponse,
         proving_service_task_id: String,
     ) -> eyre::Result<()> {
         let prover_name = &coordinator_client.prover_name;
@@ -354,7 +354,7 @@ where
     async fn submit_proof(
         &self,
         coordinator_client: &CoordinatorClient,
-        coordinator_task: &GetTaskResponseData,
+        coordinator_task: &GetTaskResponse,
         task: proving_service::QueryTaskResponse,
         status: ProofStatus,
         failure_msg: Option<String>,
@@ -370,48 +370,34 @@ where
             failure_msg: failure_msg.map(Into::into),
         };
 
-        let submit_proof_result = match coordinator_client.submit_proof(&submit_proof_req).await {
-            Ok(result) => result,
-            Err(e) => {
+        match coordinator_client.submit_proof(&submit_proof_req).await {
+            Ok(()) => {
                 info!(
                     prover_name = ?coordinator_client.prover_name,
                     ?coordinator_task.task_type,
                     ?coordinator_task.uuid,
                     ?coordinator_task.task_id,
                     ?task.task_id,
-                    error = ?e,
-                    "Failed to submit proof due to a http error"
+                    "Proof submitted successfully"
+                );
+            }
+            Err(e) => {
+                error!(
+                    prover_name = ?coordinator_client.prover_name,
+                    ?coordinator_task.task_type,
+                    ?coordinator_task.uuid,
+                    ?coordinator_task.task_id,
+                    ?task.task_id,
+                    error = %e,
+                    "Failed to submit proof due to coordinator error"
                 );
                 return Ok(());
             }
-        }
-        .into_result();
-
-        if let Err(e) = &submit_proof_result {
-            info!(
-                prover_name = ?coordinator_client.prover_name,
-                ?coordinator_task.task_type,
-                ?coordinator_task.uuid,
-                ?coordinator_task.task_id,
-                ?task.task_id,
-                code = ?e.code(),
-                msg = ?e.msg(),
-                "Failed to submit proof due to coordinator error"
-            );
-        } else {
-            info!(
-                prover_name = ?coordinator_client.prover_name,
-                ?coordinator_task.task_type,
-                ?coordinator_task.uuid,
-                ?coordinator_task.task_id,
-                ?task.task_id,
-                "Proof submitted successfully"
-            );
-        }
+        };
         Ok(())
     }
 
-    fn get_proving_input(&self, task: &GetTaskResponseData) -> eyre::Result<ProveRequest> {
+    fn get_proving_input(&self, task: &GetTaskResponse) -> eyre::Result<ProveRequest> {
         eyre::ensure!(
             self.proof_types.contains(&task.task_type),
             "unsupported task type. self: {:?}, task: {:?}, coordinator_task_uuid: {:?}, coordinator_task_id: {:?}",

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -106,7 +106,14 @@ where
         }
 
         // wait until all tasks has been done
-        while provers.join_next().await.is_some() {}
+        while let Some(r) = provers.join_next().await {
+            if r.is_err() {
+                // quit since one task has failed
+                return false;
+            } else {
+                log::info!("worker {} has completed", r.unwrap());
+            }
+        }
         true
     }
 

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -158,10 +158,12 @@ where
         {
             let task_id = coordinator_task.clone().task_id;
             debug!(task_id = %task_id, "got previous task from db");
-            let proving_task = self
-                .request_proving(coordinator_client, &coordinator_task)
-                .await?;
-            proving_task_id = proving_task.task_id;
+            if self.proving_service.read().await.is_local() {
+                let proving_task = self
+                    .request_proving(coordinator_client, &coordinator_task)
+                    .await?;
+                proving_task_id = proving_task.task_id
+            }
             return self
                 .handle_proving_progress(coordinator_client, &coordinator_task, proving_task_id)
                 .await;

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -152,10 +152,10 @@ where
         coordinator_client: &CoordinatorClient,
         task_spec: Option<(ProofType, &str)>,
     ) -> eyre::Result<()> {
-        if let (Some(coordinator_task), Some(mut proving_task_id)) = self
+        if let Some((coordinator_task, mut proving_task_id)) = self
             .db
             .as_ref()
-            .map(|db| db.get_task(coordinator_client.key_signer.get_public_key()))
+            .map(|db| db.get_task(&coordinator_client.key_signer.get_public_key()))
             .unwrap_or_default()
         {
             let task_id = coordinator_task.clone().task_id;
@@ -291,11 +291,7 @@ where
                     }
                     last_status.replace(current_status);
                     if let Some(db) = &self.db {
-                        db.set_task(
-                            public_key.clone(),
-                            coordinator_task,
-                            proving_service_task_id.clone(),
-                        );
+                        db.set_task(&public_key, coordinator_task, &proving_service_task_id);
                     }
                     sleep(self.poll_delay()).await;
                 }
@@ -317,7 +313,7 @@ where
                     )
                     .await?;
                     if let Some(db) = &self.db {
-                        db.delete_task(public_key.clone());
+                        db.delete_task(&public_key);
                     }
                     break;
                 }
@@ -341,7 +337,7 @@ where
                     )
                     .await?;
                     if let Some(db) = &self.db {
-                        db.delete_task(public_key.clone());
+                        db.delete_task(&public_key);
                     }
                     break;
                 }

--- a/src/prover/proving_service.rs
+++ b/src/prover/proving_service.rs
@@ -1,5 +1,6 @@
 use super::ProofType;
 use async_trait::async_trait;
+use std::fmt;
 
 #[async_trait]
 pub trait ProvingService {
@@ -9,19 +10,19 @@ pub trait ProvingService {
     async fn query_task(&mut self, req: QueryTaskRequest) -> QueryTaskResponse;
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GetVkRequest {
     pub proof_types: Vec<ProofType>,
     pub circuit_version: String,
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GetVkResponse {
     pub vks: Vec<String>,
     pub error: Option<String>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq, Eq, Hash)]
 pub struct ProveRequest {
     pub proof_type: ProofType,
     pub circuit_version: String,
@@ -29,7 +30,18 @@ pub struct ProveRequest {
     pub input: String,
 }
 
-#[derive(Default)]
+impl fmt::Debug for ProveRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProveRequest")
+            .field("proof_type", &self.proof_type)
+            .field("circuit_version", &self.circuit_version)
+            .field("hard_fork_name", &self.hard_fork_name)
+            .field("input", &"...")
+            .finish()
+    }
+}
+
+#[derive(Default, Clone, PartialEq)]
 pub struct ProveResponse {
     pub task_id: String,
     pub proof_type: ProofType,
@@ -46,12 +58,46 @@ pub struct ProveResponse {
     pub error: Option<String>,
 }
 
-#[derive(Default)]
+impl fmt::Debug for ProveResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut fmt = f.debug_struct("ProveResponse");
+        fmt.field("task_id", &self.task_id)
+            .field("proof_type", &self.proof_type)
+            .field("circuit_version", &self.circuit_version)
+            .field("hard_fork_name", &self.hard_fork_name)
+            .field("status", &self.status)
+            .field("created_at", &self.created_at);
+        if let Some(started_at) = &self.started_at {
+            fmt.field("started_at", started_at);
+        }
+        if let Some(finished_at) = &self.finished_at {
+            fmt.field("finished_at", finished_at);
+        }
+        if let Some(compute_time_sec) = &self.compute_time_sec {
+            fmt.field("compute_time_sec", compute_time_sec);
+        }
+        if self.input.is_some() {
+            fmt.field("input", &"..."); // Hide actual input for brevity
+        }
+        if self.proof.is_some() {
+            fmt.field("proof", &"..."); // Hide actual proof for brevity
+        }
+        if let Some(vk) = &self.vk {
+            fmt.field("vk", vk);
+        }
+        if let Some(error) = &self.error {
+            fmt.field("error", error);
+        }
+        fmt.finish()
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct QueryTaskRequest {
     pub task_id: String,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, PartialEq)]
 pub struct QueryTaskResponse {
     pub task_id: String,
     pub proof_type: ProofType,
@@ -68,7 +114,41 @@ pub struct QueryTaskResponse {
     pub error: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Default)]
+impl fmt::Debug for QueryTaskResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut fmt = f.debug_struct("QueryTaskResponse");
+        fmt.field("task_id", &self.task_id)
+            .field("proof_type", &self.proof_type)
+            .field("circuit_version", &self.circuit_version)
+            .field("hard_fork_name", &self.hard_fork_name)
+            .field("status", &self.status)
+            .field("created_at", &self.created_at);
+        if let Some(started_at) = &self.started_at {
+            fmt.field("started_at", started_at);
+        }
+        if let Some(finished_at) = &self.finished_at {
+            fmt.field("finished_at", finished_at);
+        }
+        if let Some(compute_time_sec) = &self.compute_time_sec {
+            fmt.field("compute_time_sec", compute_time_sec);
+        }
+        if self.input.is_some() {
+            fmt.field("input", &"..."); // Hide actual input for brevity
+        }
+        if self.proof.is_some() {
+            fmt.field("proof", &"..."); // Hide actual proof for brevity
+        }
+        if let Some(vk) = &self.vk {
+            fmt.field("vk", vk);
+        }
+        if let Some(error) = &self.error {
+            fmt.field("error", error);
+        }
+        fmt.finish()
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TaskStatus {
     #[default]
     Queued,

--- a/src/prover/types.rs
+++ b/src/prover/types.rs
@@ -1,91 +1,74 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use alloy_rlp::{BufMut, Decodable, Encodable};
+use serde_repr::{Deserialize_repr as DeserializeRepr, Serialize_repr as SerializeRepr};
+use strum::{Display, EnumIs, FromRepr};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializeRepr,
+    DeserializeRepr,
+    EnumIs,
+    Display,
+    FromRepr,
+)]
 #[repr(u8)]
 pub enum ProverProviderType {
     #[default]
-    Undefined,
-    Internal,
-    External,
+    Undefined = 0,
+    Internal = 1,
+    External = 2,
 }
 
-impl ProverProviderType {
-    pub fn from_u8(v: u8) -> Self {
-        match v {
-            1 => ProverProviderType::Internal,
-            2 => ProverProviderType::External,
-            _ => ProverProviderType::Undefined,
-        }
+impl Encodable for ProverProviderType {
+    fn encode(&self, out: &mut dyn BufMut) {
+        (*self as u8).encode(out);
     }
 }
 
-impl Serialize for ProverProviderType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *self {
-            ProverProviderType::Undefined => serializer.serialize_u8(0),
-            ProverProviderType::Internal => serializer.serialize_u8(1),
-            ProverProviderType::External => serializer.serialize_u8(2),
-        }
+impl Decodable for ProverProviderType {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let v = u8::decode(buf)?;
+        Ok(ProverProviderType::from_repr(v).unwrap_or(ProverProviderType::Undefined))
     }
 }
 
-impl<'de> Deserialize<'de> for ProverProviderType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let v: u8 = u8::deserialize(deserializer)?;
-        Ok(ProverProviderType::from_u8(v))
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    SerializeRepr,
+    DeserializeRepr,
+    EnumIs,
+    Display,
+    FromRepr,
+)]
+#[repr(u8)]
 pub enum ProofType {
     #[default]
-    Undefined,
-    Chunk,
-    Batch,
-    Bundle,
+    Undefined = 0,
+    Chunk = 1,
+    Batch = 2,
+    Bundle = 3,
 }
 
-impl ProofType {
-    pub fn from_u8(v: u8) -> Self {
-        match v {
-            1 => ProofType::Chunk,
-            2 => ProofType::Batch,
-            3 => ProofType::Bundle,
-            _ => ProofType::Undefined,
-        }
-    }
-
-    pub fn to_u8(self) -> u8 {
-        match self {
-            ProofType::Undefined => 0,
-            ProofType::Chunk => 1,
-            ProofType::Batch => 2,
-            ProofType::Bundle => 3,
-        }
+impl Encodable for ProofType {
+    fn encode(&self, out: &mut dyn BufMut) {
+        (*self as u8).encode(out);
     }
 }
 
-impl Serialize for ProofType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u8(self.to_u8())
-    }
-}
-
-impl<'de> Deserialize<'de> for ProofType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let v: u8 = u8::deserialize(deserializer)?;
-        Ok(ProofType::from_u8(v))
+impl Decodable for ProofType {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let v = u8::decode(buf)?;
+        Ok(ProofType::from_repr(v).unwrap_or(ProofType::Undefined))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,11 @@ pub static VERSION: &str = concat!(
     env!("ZK_VERSION", "`zkvm-prover` version and commit is required"),
 );
 
+/// Initialize the color_eyre error reporting hook.
+pub fn init_color_eyre_hook() {
+    color_eyre::install().expect("Failed to initialize color_eyre");
+}
+
 pub fn init_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use tracing_subscriber::fmt::format::FmtSpan;
 
 static DEFAULT_COMMIT: &str = "unknown";
 static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
@@ -27,6 +28,7 @@ pub fn init_tracing() {
         .with_ansi(false)
         .with_level(true)
         .with_target(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .try_init()
         .expect("Failed to initialize tracing subscriber");
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,22 +1,13 @@
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use tracing_subscriber::fmt::format::FmtSpan;
 
-static DEFAULT_COMMIT: &str = "unknown";
-static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-
-pub const TAG: &str = "v0.0.0";
-pub const DEFAULT_ZK_VERSION: &str = "000000-000000";
-
-fn init_version() -> String {
-    let commit = option_env!("GIT_REV").unwrap_or(DEFAULT_COMMIT);
-    let tag = option_env!("GO_TAG").unwrap_or(TAG);
-    let zk_version = option_env!("ZK_VERSION").unwrap_or(DEFAULT_ZK_VERSION);
-    format!("{tag}-{commit}-{zk_version}")
-}
-
-pub fn get_version() -> String {
-    VERSION.get_or_init(init_version).clone()
-}
+pub static VERSION: &str = concat!(
+    env!("GO_TAG", "semver from `./common/version.go` is required"),
+    "-",
+    env!("GIT_REV", "git rev of `scroll` is required"),
+    "-",
+    env!("ZK_VERSION", "`zkvm-prover` version and commit is required"),
+);
 
 pub fn init_tracing() {
     tracing_subscriber::fmt()


### PR DESCRIPTION
Printing backtrace for "empty task" error waste many log space and is nonsense.

We can always master the status inside handle_task loop without backtrace carried by any::Error, This PR has elimiated the debug output for error